### PR TITLE
Dev vnext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### [@coreui/vue](https://coreui.io/) changelog
 
+##### v2.0.2
+- fix(AsideToggler): add missing `display { default:'lg' }` prop value
+- fix(AsideToggler): add missing `defaultOpen` prop value handling
+- refactor(shared): add missing `index.js`
+
 ##### v2.0.1
 - fix(SidebarNav): dirty fix for `rtl` ps scrolling issue
 - refactor(SidebarMinimizer): extract `togglePs` mixin

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coreui/vue",
   "description": "CoreUI Vue Bootstrap 4 layout components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "main": "dist/coreui-vue.common.js",
   "module": "dist/coreui-vue.esm.js",

--- a/src/components/Aside/AsideToggler.vue
+++ b/src/components/Aside/AsideToggler.vue
@@ -22,7 +22,7 @@ export default {
     },
     display: {
       type: String,
-      default: ''
+      default: 'lg'
     },
     mobile: {
       type: Boolean,
@@ -35,6 +35,9 @@ export default {
         'navbar-toggler'
       ]
     }
+  },
+  mounted: function() {
+    this.toggle(this.defaultOpen)
   },
   methods: {
     toggle (force) {

--- a/src/components/__tests__/__snapshots__/AsideToggler.js.snap
+++ b/src/components/__tests__/__snapshots__/AsideToggler.js.snap
@@ -3,7 +3,7 @@
 exports[`AsideToggler.vue renders correctly 1`] = `
 <button
   class="navbar-toggler"
-  display=""
+  display="lg"
   type="button"
 >
   <span

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,0 +1,3 @@
+import { sidebarCssClasses, asideMenuCssClasses, validBreakpoints, checkBreakpoint } from './classes'
+
+export { sidebarCssClasses, asideMenuCssClasses, validBreakpoints, checkBreakpoint }


### PR DESCRIPTION
##### v2.0.2
- fix(AsideToggler): add missing `display { default:'lg' }` prop value
- fix(AsideToggler): add missing `defaultOpen` prop value handling
- refactor(shared): add missing `index.js`