### PR TITLE
Ignore linting error

### DIFF
--- a/src/components/Sidebar/SidebarNav.vue
+++ b/src/components/Sidebar/SidebarNav.vue
@@ -89,6 +89,7 @@ export default {
     }
   },
   methods: {
+  // eslint-disable-next-line
     scrollHandle (evt) {
       // console.log(evt)
     }


### PR DESCRIPTION
Linting is complaining about the evt variable not being used:

`error: 'evt' is defined but never used`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
