### PR TITLE
Update SidebarNavLink.vue

### DIFF
--- a/src/components/Sidebar/SidebarNavLink.vue
+++ b/src/components/Sidebar/SidebarNavLink.vue
@@ -1,14 +1,20 @@
 <template>
   <a :class="classList" v-bind="attributes" tabindex="-1" v-on:click.stop.prevent v-if="isDisabled">
-    <i :class="classIcon"></i> <span>{{name}}</span>
+    <slot name="icon"><i :class="classIcon"></i></slot>
+    {{name}}
+    <slot name="append-icon"></slot>
     <b-badge v-if="badge && badge.text" :variant="badge.variant">{{badge.text}}</b-badge>
   </a>
   <a :href="url" :class="classList" v-bind="attributes" v-else-if="isExternalLink">
-    <i :class="classIcon"></i> {{name}}
+    <slot name="icon"><i :class="classIcon"></i></slot>
+    {{name}}
+    <slot name="append-icon"></slot>
     <b-badge v-if="badge && badge.text" :variant="badge.variant">{{badge.text}}</b-badge>
   </a>
   <router-link :to="url" :class="classList" v-bind="attributes" v-else>
-    <i :class="classIcon"></i> {{name}}
+    <slot name="icon"><i :class="classIcon"></i></slot>
+    {{name}}
+    <slot name="append-icon"></slot>
     <b-badge v-if="badge && badge.text" :variant="badge.variant">{{badge.text}}</b-badge>
   </router-link>
 </template>


### PR DESCRIPTION
Added default slots to icons for better control

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In some use-cases, one may need to check for existence of an icon in the nav item, in which case one would wish to provide a default icon. With these slots, it becomes possible to override the default setup. Also, one may wish to append (not pre-prend) the icon. A slot for this provides perfect sense.

Examples:
```vue
<sidebar-nav-link :name="item.name" :url="item.url" :icon="item.icon" :badge="item.badge" :variant="item.variant" :attributes="item.attributes">
    <template slot="icon"></template>
    <template slot="append-icon">
         <i class="nav-icon material-icons">{{ item.icon ? item.icon : 'arrow_right_alt' }}</i>
    </template>
</sidebar-nav-link>
```