### PR TITLE
Add XL to Modal Validator

### DIFF
--- a/src/components/modal/CModal.vue
+++ b/src/components/modal/CModal.vue
@@ -68,7 +68,7 @@ export default {
     title: String,
     size: {
       type: String,
-      validator: val => ['', 'sm', 'lg'].includes(val)
+      validator: val => ['', 'sm', 'lg', 'xl'].includes(val)
     },
     color: String,
     borderColor: String,


### PR DESCRIPTION
While are using the new Version in our Application we set the modal to xl and it is working 
I just want to add it also to the validator so we do not get any errors anymore

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
