### PR TITLE
fix #134: Add new function to emit on splitButtonPress

### DIFF
--- a/src/components/dropdown/CDropdown.vue
+++ b/src/components/dropdown/CDropdown.vue
@@ -8,7 +8,7 @@
     <slot name="toggler">
       <component
         :is="togglerTag"
-        v-on="{ click: splittedToggler ? hide : toggle }"
+        v-on="{ click: splittedToggler ? splitButtonPress : toggle }"
         :class="computedTogglerClasses"
         v-bind="splittedToggler ? '' : togglerAttrs"
       >
@@ -118,6 +118,11 @@ export default {
 
     hide () {
       this.visible = false
+    },
+
+    splitButtonPress () {
+      this.visible = false
+        this.$emit('splitButtonPress')
     },
 
     toggle (e) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This should allow parent vue components to attach to the button press of the "splittedToggle" button.