### PR TITLE
fix(CDataTable): issue with loading and no-items-view slots

### DIFF
--- a/src/components/table/CDataTable.vue
+++ b/src/components/table/CDataTable.vue
@@ -159,7 +159,7 @@
               </td>
             </tr>
           </template>
-          <tr v-if="!currentItems.length">
+          <tr v-if="!currentItems.length && !loading">
             <td :colspan="colspan">
               <slot name="no-items-view">
                 <div class="text-center my-5">


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

if loading the items in the table asynchronously and passing the loading
prop to the c-data-table, until the request would be done, the table
would display both the no-item-slot and the loading slot. this fix
changes it so that while loading, do not display the no-items-slot