### PR TITLE
feat: additional 'scrollable' property for CModal.vue

### DIFF
--- a/src/components/modal/CModal.vue
+++ b/src/components/modal/CModal.vue
@@ -28,7 +28,7 @@
               <slot name="footer">
                 <button
                   type="button"
-                  class="btn btn-secondary" 
+                  class="btn btn-secondary"
                   @click="hide($event)"
                 >
                   Cancel
@@ -65,6 +65,7 @@ export default {
   props: {
     show: Boolean,
     centered: Boolean,
+    scrollable: Boolean,
     title: String,
     size: {
       type: String,
@@ -118,6 +119,7 @@ export default {
         'modal-dialog',
         {
           'modal-dialog-centered': this.centered,
+          'modal-dialog-scrollable': this.scrollable,
           [`modal-${this.size}`]: this.size
         }
       ]
@@ -149,7 +151,7 @@ export default {
     hide (e, accept = false) {
       this.$emit('update:show', false, e, accept)
       if(this.visible){
-        window.removeEventListener("keydown", this.hideEsc ); 
+        window.removeEventListener("keydown", this.hideEsc );
       }
     },
     hideEsc (event){


### PR DESCRIPTION
I was trying to add the class [`modal-dialog-scrollable`](https://getbootstrap.com/docs/4.6/components/modal/#scrolling-long-content) to the appropriate modal element, which was not possible.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The commit removes two unnecessary whitespaces, that my IDE removed automatically. I can revert them if needed.