### PR TITLE
feat(CModal): Improve close behavior

### DIFF
--- a/src/components/modal/CModal.vue
+++ b/src/components/modal/CModal.vue
@@ -4,7 +4,8 @@
       :class="modalClasses"
       tabindex="-1"
       role="dialog"
-      @click="modalClick($event)"
+      @mousedown="mouseDown($event)"
+      @mouseup="mouseUp($event)"
     >
       <div :class="dialogClasses" role="document">
         <div :class="contentClasses">
@@ -92,7 +93,8 @@ export default {
     return {
       visible: this.show,
       isTransitioning: false,
-      timeout: null
+      timeout: null,
+      mouseDownTarget: null
     }
   },
   computed: {
@@ -143,10 +145,13 @@ export default {
     }
   },
   methods: {
-    modalClick (e) {
-      if (e.target === this.$el.firstElementChild && this.closeOnBackdrop) {
+    mouseUp (e) {
+      if (e.target === this.$el.firstElementChild && this.mouseDownTarget === this.$el.firstElementChild && this.closeOnBackdrop) {
         this.hide(e)
       }
+    },
+    mouseDown (e) {
+      this.mouseDownTarget = e.target;
     },
     hide (e, accept = false) {
       this.$emit('update:show', false, e, accept)


### PR DESCRIPTION
Modal is closed when mouse up event happens on backdrop. This can lead to a strange behaviour for the user. E.g. user wants to select and copy all text in modal. When selecting all text and the mouse up happens outside of the modal just closes the modal and makes it impossible to copy the selected text.

Now only closes the modal when the mousedown and mouseup event happens outside of the modal.

This closes https://github.com/coreui/coreui-vue/issues/153

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/coreui/coreui-vue/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
