### PR TITLE
Fixing modal bug where its not possible to open it again

### DIFF
--- a/packages/coreui-vue/src/components/modal/CModal.ts
+++ b/packages/coreui-vue/src/components/modal/CModal.ts
@@ -142,6 +142,7 @@ const CModal = defineComponent({
       })
       document.body.classList.remove('modal-open')
       el.classList.remove('show')
+      el.style.display = 'none'
     }
     const handleAfterLeave = (el: RendererElement) => {
       window.removeEventListener('mousedown', handleMouseDown)


### PR DESCRIPTION
There is a bug on vuejs modal component (not working either on the official documentation), where closing it will let an overlay and prevent to open the modal again. Adding this line has make it work