### PR TITLE
Hide backdrop setting visibility to false on close

### DIFF
--- a/packages/coreui-vue/src/components/backdrop/CBackdrop.ts
+++ b/packages/coreui-vue/src/components/backdrop/CBackdrop.ts
@@ -30,6 +30,7 @@ const CBackdrop = defineComponent({
         done()
       })
       el.classList.remove('show')
+      el.style.visibility = 'hidden'
     }
     const handleAfterLeave = (el: RendererElement) => {
       el.classList.add('d-none')


### PR DESCRIPTION
Like the other pull request, when using backdrop on a modal, it keeps the overlay when closing. This fix it