### PR TITLE
Fix (v-c-tooltip): not hiding tooltips on component unmount

### DIFF
--- a/packages/coreui-vue/src/directives/v-c-tooltip.ts
+++ b/packages/coreui-vue/src/directives/v-c-tooltip.ts
@@ -92,7 +92,7 @@ export default {
       })
     }
   },
-  beforeUnmount(binding: DirectiveBinding): void {
+  beforeUnmount(_el: HTMLElement, binding: DirectiveBinding): void {
     const tooltip = binding.arg && document.getElementById(binding.arg)
     tooltip && tooltip.remove()
   },


### PR DESCRIPTION
We found a bug on the coreui tooltip feature. The tooltips where not hiding if binding component was unmount. E.g. on click of a button with a router link and a tooltip.

**What kind of change does this PR introduce? (check at least one)**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change? (check one)**

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the develop branch (or to a previous version branch), not the master branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. fix #xxx[,#xxx], where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a new feature, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Other information: