### PR TITLE
CLink emit click's argument contains the mouse events

### DIFF
--- a/packages/coreui-vue/src/components/link/CLink.ts
+++ b/packages/coreui-vue/src/components/link/CLink.ts
@@ -42,7 +42,7 @@ const CLink = defineComponent({
   ],
   setup(props, { slots, emit }) {
     const handleClick = (mouseEvent: MouseEvent) => {
-      emit('click', mouseEvent, props.href)
+      emit('click', props.href, mouseEvent)
     }
     return () =>
       h(

--- a/packages/coreui-vue/src/components/link/CLink.ts
+++ b/packages/coreui-vue/src/components/link/CLink.ts
@@ -41,8 +41,8 @@ const CLink = defineComponent({
     'click',
   ],
   setup(props, { slots, emit }) {
-    const handleClick = () => {
-      emit('click', props.href)
+    const handleClick = (mouseEvent: MouseEvent) => {
+      emit('click', mouseEvent, props.href)
     }
     return () =>
       h(


### PR DESCRIPTION
W/o providing the (native) mouse event no consumer can react accordingly.
With this change the mouse event is emitted as first argument in the click event.

https://github.com/coreui/coreui-vue/blob/a5c0ad536950d30cac0ef24fd4982b44a9a1df57/packages/coreui-vue/src/components/link/CLink.ts#L44-L46