### PR TITLE
CFormControlWrapper: Fixed Vue's warning about non-function value for default slot for `floatingLabel`

### DIFF
--- a/packages/coreui-vue/src/components/form/CFormControlWrapper.ts
+++ b/packages/coreui-vue/src/components/form/CFormControlWrapper.ts
@@ -43,7 +43,7 @@ const CFormControlWrapper = defineComponent({
   setup(props, { slots }) {
     return () =>
       props.floatingLabel
-        ? h(CFormFloating, [
+        ? h(CFormFloating, () => [
             slots.default && slots.default(),
             h(
               CFormLabel,


### PR DESCRIPTION
Fixes the warning Vue emits when on form input the `floatingLabel` is used.
```
[Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance. 
  at <CFormFloating> 
  at <CFormControlWrapper describedby=undefined feedback=undefined feedbackInvalid="Zahl muss eingegeben werden."  ... > 
  at <CFormInput id="pu-form-kontaktzeit" class="mb-3" floatingLabel="Kontaktzeit [s]"  ... > 
  at <CCol> 
  at ...
```

Cf. [StackOverflow: "Non-function value encountered for default slot." in Vue 3 Composition API component](https://stackoverflow.com/questions/69875273/non-function-value-encountered-for-default-slot-in-vue-3-composition-api-comp)