### PR TITLE
CFormInput model-prop allow String and Number

### DIFF
--- a/packages/coreui-vue/src/components/form/CFormInput.ts
+++ b/packages/coreui-vue/src/components/form/CFormInput.ts
@@ -67,7 +67,7 @@ const CFormInput = defineComponent({
      * The default name for a value passed using v-model.
      */
     modelValue: {
-      type: String,
+      type: [String, Number],
       default: undefined,
     },
     /**


### PR DESCRIPTION
For `<CFormInput type="number" v-model.number="myNumberProperty" />` a validation error will occur otherwise.