### PR TITLE
CFormInput modelValue = 0 (number) handled correctly

### DIFF
--- a/packages/coreui-vue/src/components/form/CFormInput.ts
+++ b/packages/coreui-vue/src/components/form/CFormInput.ts
@@ -188,7 +188,7 @@ const CFormInput = defineComponent({
                 onInput: (event: InputEvent) => handleInput(event),
                 readonly: props.readonly,
                 type: props.type,
-                ...(props.modelValue && { value: props.modelValue }),
+                ...((props.modelValue || props.modelValue === 0) && { value: props.modelValue })
               },
               slots.default && slots.default(),
             ),


### PR DESCRIPTION
This wasn't updated in https://github.com/coreui/coreui-vue/pull/214 (my fault).

If `modelValue = 0` then the check https://github.com/coreui/coreui-vue/blob/b85adb2f6aea52189b8aa2a2733698b542a19991/packages/coreui-vue/src/components/form/CFormInput.ts#L191 fails, so no modelValue is set thus resulting in an empty input-form to be displayed.

This PR fixes that by explicitely checking for `=== 0` too.