### PR TITLE
Allow using v-model on accordion activeItemKey

### DIFF
--- a/packages/coreui-vue/src/components/accordion/CAccordion.ts
+++ b/packages/coreui-vue/src/components/accordion/CAccordion.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, provide, ref } from 'vue'
+import { defineComponent, h, provide, ref, watch } from 'vue'
 
 const CAccordion = defineComponent({
   name: 'CAccordion',
@@ -16,14 +16,19 @@ const CAccordion = defineComponent({
      */
     flush: Boolean,
   },
+  emits: ['update:activeItemKey'],
   setup(props, { slots }) {
     const activeItemKey = ref(props.activeItemKey)
     const setActiveItemKey = (key: string | number) => {
-      activeItemKey.value = key
+      emit('update:activeItemKey', key)
     }
     provide('activeItemKey', activeItemKey)
     provide('alwaysOpen', props.alwaysOpen)
     provide('setActiveItemKey', setActiveItemKey)
+    
+    watch(() => props.activeItemKey, (value) => {
+      activeItemKey.value = value;
+    })
 
     return () =>
       h(


### PR DESCRIPTION
I needed a reactive way to change the currently open accordion item, and this seems to do the trick.