### PR TITLE
Add the `as` property in the `CFooter` component to use semantic tag

### DIFF
--- a/packages/coreui-vue/src/components/footer/CFooter.ts
+++ b/packages/coreui-vue/src/components/footer/CFooter.ts
@@ -4,6 +4,13 @@ const CFooter = defineComponent({
   name: 'CFooter',
   props: {
     /**
+     * Component used for the root node. Either a string to use a HTML element or a component.
+     */
+    as: {
+      type: String,
+      default: 'div',
+    },
+    /**
      * Place footer in non-static positions.
      *
      * @values 'fixed', 'sticky'
@@ -18,7 +25,7 @@ const CFooter = defineComponent({
   setup(props, { slots }) {
     return () =>
       h(
-        'div',
+        props.as,
         { class: ['footer', { [`footer-${props.position}`]: props.position }] },
         slots.default && slots.default(),
       )

--- a/packages/coreui-vue/src/components/footer/__tests__/CFooter.spec.ts
+++ b/packages/coreui-vue/src/components/footer/__tests__/CFooter.spec.ts
@@ -19,6 +19,15 @@ const customWrapper = mount(Component, {
   },
 })
 
+const customWrapperTwo = mount(Component, {
+  propsData: {
+    as: 'footer',
+  },
+  slots: {
+    default: 'Default slot',
+  },
+})
+
 describe(`Loads and display ${ComponentName} component`, () => {
   it('has a name', () => {
     expect(Component.name).toMatch(ComponentName)
@@ -40,5 +49,15 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.text()).toContain('Default slot')
     expect(customWrapper.classes('footer')).toBe(true)
     expect(customWrapper.classes('footer-fixed')).toBe(true)
+  })
+})
+
+describe(`Customize (number two) ${ComponentName} component`, () => {
+  it('renders correctly', () => {
+    expect(customWrapperTwo.html()).toMatchSnapshot()
+  })
+
+  it('tag name is custom', () => {
+    expect(customWrapperTwo.element.tagName).toBe('FOOTER')
   })
 })


### PR DESCRIPTION
The component `CFooter` write the tag `div`, with this custom property we can use `footer` tag

```html
<CFooter>My footer</CFooter>
// Out put: <div class="footer">My footer</div>

<CFooter as="footer">My footer</CFooter>
// Out put: <footer class="footer">My footer</footer>
```