### PR TITLE
Add the `as` property in the `CHeader` component to use semantic tag

### DIFF
--- a/packages/coreui-vue/src/components/header/CHeader.ts
+++ b/packages/coreui-vue/src/components/header/CHeader.ts
@@ -4,6 +4,13 @@ const CHeader = defineComponent({
   name: 'CHeader',
   props: {
     /**
+     * Component used for the root node. Either a string to use a HTML element or a component.
+     */
+    as: {
+      type: String,
+      default: 'div',
+    },
+    /**
      * Defines optional container wrapping children elements.
      *
      * @values boolean, 'sm', 'md', 'lg', 'xl', 'xxl', 'fluid'
@@ -31,7 +38,7 @@ const CHeader = defineComponent({
   setup(props, { slots }) {
     return () =>
       h(
-        'div',
+        props.as,
         { class: ['header', { [`header-${props.position}`]: props.position }] },
         props.container
           ? h(

--- a/packages/coreui-vue/src/components/header/__tests__/CHeader.spec.ts
+++ b/packages/coreui-vue/src/components/header/__tests__/CHeader.spec.ts
@@ -20,6 +20,15 @@ const customWrapper = mount(Component, {
   },
 })
 
+const customWrapperTwo = mount(Component, {
+  propsData: {
+    as: 'header',
+  },
+  slots: {
+    default: 'Default slot',
+  },
+})
+
 describe(`Loads and display ${ComponentName} component`, () => {
   it('has a name', () => {
     expect(Component.name).toMatch(ComponentName)
@@ -42,5 +51,15 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.classes('header')).toBe(true)
     expect(customWrapper.classes('header-fixed')).toBe(true)
     expect(customWrapper.find('.container-lg').classes('container-lg')).toBe(true)
+  })
+})
+
+
+describe(`Customize (number two) ${ComponentName} component`, () => {
+  it('renders correctly', () => {
+    expect(customWrapperTwo.html()).toMatchSnapshot()
+  })
+  it('tag name is custom', () => {
+    expect(customWrapperTwo.element.tagName).toBe('HEADER')
   })
 })

--- a/packages/docs/api/header/CHeader.api.md
+++ b/packages/docs/api/header/CHeader.api.md
@@ -8,7 +8,8 @@ import CHeader from '@coreui/vue/src/components/header/CHeader'
 
 #### Props
 
-| Prop name     | Description                                            | Type            | Values                                                        | Default |
-| ------------- | ------------------------------------------------------ | --------------- | ------------------------------------------------------------- | ------- |
-| **container** | Defines optional container wrapping children elements. | boolean\|string | `boolean`, `'sm'`, `'md'`, `'lg'`, `'xl'`, `'xxl'`, `'fluid'` | -       |
-| **position**  | Place header in non-static positions.                  | string          | `'fixed'`, `'sticky'`                                         | -       |
+| Prop name     | Description                                                                             | Type            | Values                                                        | Default |
+| ------------- | --------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------- | ------- |
+| **as**        | Component used for the root node. Either a string to use a HTML element or a component. | string          | -                                                             | 'div'   |
+| **container** | Defines optional container wrapping children elements.                                  | boolean\|string | `boolean`, `'sm'`, `'md'`, `'lg'`, `'xl'`, `'xxl'`, `'fluid'` | -       |
+| **position**  | Place header in non-static positions.                                                   | string          | `'fixed'`, `'sticky'`                                         | -       |


### PR DESCRIPTION
The component `CHeader` write the tag div, with this custom property we can use header tag

```html
<CHeader> ... </CHeader>
// Out put: <div class="header"> ... </div>

<CHeader as="header"> ... </CHeader>
// Out put: <header class="header"> ... </header>
```