### PR TITLE
Added formatter to column object

### DIFF
--- a/packages/coreui-vue/src/components/table/CTable.ts
+++ b/packages/coreui-vue/src/components/table/CTable.ts
@@ -238,7 +238,7 @@ const CTable = defineComponent({
                             default: () => [
                               columnNames.value &&
                                 columnNames.value.map(
-                                  (colName: string) =>
+                                  (colName: string, idx: number) =>
                                     item[colName] !== undefined &&
                                     h(
                                       CTableDataCell,
@@ -251,7 +251,14 @@ const CTable = defineComponent({
                                           }),
                                       },
                                       {
-                                        default: () => item[colName],
+                                        default: () => {
+                                          const column = props.columns![idx];
+                                          const value  = item[colName];
+                                          
+                                          return typeof column === "object" && column.formatter
+                                            ? column.formatter(value)
+                                            : value;
+                                        }
                                       },
                                     ),
                                 ),

--- a/packages/coreui-vue/src/components/table/types.ts
+++ b/packages/coreui-vue/src/components/table/types.ts
@@ -4,7 +4,8 @@ export type Column = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _style?: any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _props?: any
+  _props?: any,
+  formatter?: (value: unknown) => string
 }
 
 export type FooterItem = {


### PR DESCRIPTION
The table data items are displayed by simple `toString` (internally).

This PR adds the optional property `formatter`, so you can do something like
```ts
function formatTimeStamp(value: Date): string {
    return value.toLocaleString();
}

function formatNumber(value: number): string {
    return value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 1 });
}

const columns = [
    { key: "timeStampUtc", label: "Timestamp", formatter: formatTimeStamp},
    { key: "mean"        , label: "Mean"     , formatter: formatNumber   },
    { key: "median"      , label: "Median"   , formatter: formatNumber   },
    { key: "sigma"       , label: "Sigma"    , formatter: formatNumber   }
];
```
in order to specify a _formatter_, that will convert each item's property according the given formatter-function.

> [!NOTE]
> It's optional to specify the `formatter`