### PR TITLE
Fix: CButton variant styling when undefined

### DIFF
--- a/packages/coreui-vue/src/components/button/CButton.ts
+++ b/packages/coreui-vue/src/components/button/CButton.ts
@@ -93,8 +93,9 @@ export const CButton = defineComponent({
         {
           class: [
             'btn',
-            props.variant && props.color ? `btn-${props.variant}-${props.color}` : `btn-${props.variant}`,
             {
+              [`btn-${props.variant}-${props.color}`]: props.color && props.variant,
+              [`btn-${props.variant}`]: !props.color && props.variant,
               [`btn-${props.color}`]: props.color && !props.variant,
               [`btn-${props.size}`]: props.size,
               active: props.active,


### PR DESCRIPTION
This PR will fix where the CButton defaults to 'btn-undefined' when the variant is not declared.

### Example, pre-PR with no declared `variant` attribute on a CButton component:
<img width="484" height="44" alt="image" src="https://github.com/user-attachments/assets/0993b0ff-3df9-413f-acef-9062e813dca9" />

### New Behavior:
* If the `variant` attribute is undeclared, it will not add `'btn-undefined'` like it had been doing.
* If both the `color` and `variant` attributes are declared, it will `'btn-{variant}-{color}'` like it currently does.
* If the `color` attribute is undeclared and the `variant` attribute is declared, it will `'btn-{variant}'` like it currently does.