### PR TITLE
docs: add AddedIn badge component

### DIFF
--- a/packages/docs/.vuepress/config.ts
+++ b/packages/docs/.vuepress/config.ts
@@ -87,6 +87,7 @@ export default defineUserConfig({
     }),
     registerComponentsPlugin({
       components: {
+        AddedIn: path.resolve(__dirname, './src/client/components/AddedIn.vue'),
         Callout: path.resolve(__dirname, './src/client/components/Callout.vue'),
         ScssDocs: path.resolve(__dirname, './src/client/components/ScssDocs.vue'),
       },

--- a/packages/docs/.vuepress/src/client/components/AddedIn.vue
+++ b/packages/docs/.vuepress/src/client/components/AddedIn.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps({
+  version: String,
+})
+</script>
+
+<template>
+  <small
+    class="d-inline-flex mb-3 px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2"
+  >
+    Added in v{{ props.version }}
+  </small>
+</template>


### PR DESCRIPTION
Adds the reusable `<AddedIn version="…" />` docs badge to the free repo (parity with coreui-vue-pro). New `AddedIn.vue` client component, registered globally via `registerComponentsPlugin` so docs pages can mark when a feature was added.