### PR TITLE
feat(CNavGroup): support controlled visibility and v-model:visible

### DIFF
--- a/packages/coreui-vue/src/components/nav/CNavGroup.ts
+++ b/packages/coreui-vue/src/components/nav/CNavGroup.ts
@@ -1,16 +1,18 @@
 import {
   computed,
   defineComponent,
+  getCurrentInstance,
   h,
   inject,
-  onMounted,
   provide,
   Ref,
   ref,
   RendererElement,
   Transition,
   useId,
+  vShow,
   watch,
+  withDirectives,
 } from 'vue'
 
 import { executeAfterTransition } from '../../utils/transition'
@@ -30,7 +32,8 @@ const CNavGroup = defineComponent({
      */
     compact: Boolean,
     /**
-     * Show nav group items.
+     * Show nav group items. Acts as the initial state on its own, or as the controlled value
+     * when paired with a `v-model:visible` / `@update:visible` listener.
      */
     visible: {
       type: Boolean,
@@ -40,21 +43,26 @@ const CNavGroup = defineComponent({
   emits: ['update:visible', 'visible-change'],
   setup(props, { slots, emit }) {
     const key = useId()
+    const instance = getCurrentInstance()
+    const hasUpdateListener = Boolean(instance?.vnode.props?.['onUpdate:visible'])
 
     const parentActiveKey = inject<Ref<string | undefined> | undefined>(
       'cNavGroupActiveKey',
-      undefined,
+      undefined
     )
     const parentSetActiveKey = inject<((key?: string) => void) | undefined>(
       'cNavGroupSetActiveKey',
-      undefined,
+      undefined
     )
+    const parentOpenBranch = inject<(() => void) | undefined>('cNavGroupOpenBranch', undefined)
+
+    const controlled = computed(() => props.visible !== undefined && hasUpdateListener)
 
     const internal = ref(Boolean(props.visible))
 
     const visible = computed(() => {
-      if (props.visible !== undefined) {
-        return props.visible
+      if (controlled.value) {
+        return props.visible as boolean
       }
 
       if (parentActiveKey) {
@@ -70,23 +78,62 @@ const CNavGroup = defineComponent({
       activeGroupKey.value = value
     })
 
-    const showClass = ref(visible.value)
+    const openBranch = () => {
+      parentSetActiveKey?.(key)
+      parentOpenBranch?.()
+    }
+    provide('cNavGroupOpenBranch', openBranch)
 
-    onMounted(() => {
-      if (props.visible && parentSetActiveKey) {
-        parentSetActiveKey(key)
+    // Seed the accordion / local state from the `visible` prop: opens default-open groups and
+    // follows later changes (and keeps controlled groups in sync). Watching `props.visible`
+    // keeps this from re-running on accordion changes, so a default-open group can be collapsed
+    // manually.
+    watch(
+      () => props.visible,
+      (value) => {
+        if (value === undefined) {
+          return
+        }
+
+        if (parentSetActiveKey) {
+          if (value) {
+            parentSetActiveKey(key)
+          } else if (parentActiveKey && parentActiveKey.value === key) {
+            parentSetActiveKey(undefined)
+          }
+        } else {
+          internal.value = value
+        }
+      },
+      { immediate: true }
+    )
+
+    // The items stay mounted (so nested active links can open their ancestors), so the `show`
+    // class drives their visibility. Add it as soon as the group is visible; the leave
+    // transition removes it after the collapse finishes (`handleAfterLeave`).
+    const showClass = ref(visible.value)
+    watch(visible, (value) => {
+      if (value) {
+        showClass.value = true
       }
     })
 
-    watch(visible, (value) => {
-      if (props.visible !== undefined && parentSetActiveKey) {
-        if (value) {
-          parentSetActiveKey(key)
-        } else if (parentActiveKey && parentActiveKey.value === key) {
-          parentSetActiveKey(undefined)
+    // Accordion: when another branch opens, a controlled group must close too. As its
+    // visibility is owned by the parent, request the change through `update:visible`.
+    watch(
+      () => parentActiveKey?.value,
+      (activeKey) => {
+        if (!controlled.value || !props.visible) {
+          return
+        }
+
+        if (activeKey !== undefined && activeKey !== key) {
+          emit('update:visible', false)
         }
       }
+    )
 
+    watch(visible, (value) => {
       emit('visible-change', value)
     })
 
@@ -96,11 +143,11 @@ const CNavGroup = defineComponent({
       const next = !visible.value
       emit('update:visible', next)
 
-      if (props.visible !== undefined) {
+      if (controlled.value) {
         return
       }
 
-      if (parentActiveKey && parentSetActiveKey) {
+      if (parentSetActiveKey) {
         parentSetActiveKey(next ? key : undefined)
       } else {
         internal.value = next
@@ -156,7 +203,7 @@ const CNavGroup = defineComponent({
                 href: '#',
                 onClick: handleTogglerClick,
               },
-              slots.togglerContent && slots.togglerContent(),
+              slots.togglerContent && slots.togglerContent()
             ),
           h(
             Transition,
@@ -171,22 +218,24 @@ const CNavGroup = defineComponent({
             },
             {
               default: () =>
-                visible.value &&
-                h(
-                  props.as === 'div' ? 'div' : 'ul',
-                  {
-                    class: [
-                      'nav-group-items',
-                      {
-                        compact: props.compact,
-                      },
-                    ],
-                  },
-                  slots.default && slots.default(),
+                withDirectives(
+                  h(
+                    props.as === 'div' ? 'div' : 'ul',
+                    {
+                      class: [
+                        'nav-group-items',
+                        {
+                          compact: props.compact,
+                        },
+                      ],
+                    },
+                    slots.default && slots.default()
+                  ),
+                  [[vShow, visible.value]]
                 ),
-            },
+            }
           ),
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/nav/CNavGroup.ts
+++ b/packages/coreui-vue/src/components/nav/CNavGroup.ts
@@ -7,12 +7,8 @@ import {
   provide,
   Ref,
   ref,
-  RendererElement,
-  Transition,
   useId,
-  vShow,
   watch,
-  withDirectives,
 } from 'vue'
 
 import { executeAfterTransition } from '../../utils/transition'
@@ -45,6 +41,8 @@ const CNavGroup = defineComponent({
     const key = useId()
     const instance = getCurrentInstance()
     const hasUpdateListener = Boolean(instance?.vnode.props?.['onUpdate:visible'])
+
+    const navGroupItemsRef = ref<HTMLElement>()
 
     const parentActiveKey = inject<Ref<string | undefined> | undefined>(
       'cNavGroupActiveKey',
@@ -108,16 +106,6 @@ const CNavGroup = defineComponent({
       { immediate: true }
     )
 
-    // The items stay mounted (so nested active links can open their ancestors), so the `show`
-    // class drives their visibility. Add it as soon as the group is visible; the leave
-    // transition removes it after the collapse finishes (`handleAfterLeave`).
-    const showClass = ref(visible.value)
-    watch(visible, (value) => {
-      if (value) {
-        showClass.value = true
-      }
-    })
-
     // Accordion: when another branch opens, a controlled group must close too. As its
     // visibility is owned by the parent, request the change through `update:visible`.
     watch(
@@ -133,9 +121,43 @@ const CNavGroup = defineComponent({
       }
     )
 
-    watch(visible, (value) => {
-      emit('visible-change', value)
-    })
+    // Animate the height of the always-mounted items, after the `show` class (driven straight
+    // from `visible`, so the toggler indicator reacts immediately). `display` is forced while
+    // collapsing to override the `.nav-group:not(.show) .nav-group-items { display: none }` rule.
+    watch(
+      visible,
+      (value) => {
+        emit('visible-change', value)
+
+        const el = navGroupItemsRef.value
+        if (!el) {
+          return
+        }
+
+        el.style.display = 'block'
+
+        // Each branch sets the starting height, forces a reflow by reading `offsetHeight`, then
+        // sets the target height. The reflow makes the browser commit the starting value, so the
+        // CSS height transition runs instead of both writes collapsing into a single frame.
+        if (value) {
+          el.style.height = '0px'
+          el.offsetHeight // eslint-disable-line @typescript-eslint/no-unused-expressions
+          el.style.height = `${el.scrollHeight}px`
+          executeAfterTransition(() => {
+            el.style.height = 'auto'
+          }, el)
+        } else {
+          el.style.height = `${el.scrollHeight}px`
+          el.offsetHeight // eslint-disable-line @typescript-eslint/no-unused-expressions
+          el.style.height = '0px'
+          executeAfterTransition(() => {
+            el.style.display = ''
+            el.style.height = ''
+          }, el)
+        }
+      },
+      { flush: 'post' }
+    )
 
     const handleTogglerClick = (event: Event) => {
       event.preventDefault()
@@ -154,44 +176,11 @@ const CNavGroup = defineComponent({
       }
     }
 
-    const handleBeforeEnter = (el: RendererElement) => {
-      el.style.height = '0px'
-      showClass.value = true
-    }
-
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const handleEnter = (el: RendererElement, done: () => void) => {
-      executeAfterTransition(() => done(), el as HTMLElement)
-      el.style.height = `${el.scrollHeight}px`
-    }
-
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const handleAfterEnter = (el: RendererElement) => {
-      el.style.height = 'auto'
-    }
-
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const handleBeforeLeave = (el: RendererElement) => {
-      el.style.height = `${el.scrollHeight}px`
-    }
-
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const handleLeave = (el: RendererElement, done: () => void) => {
-      executeAfterTransition(() => done(), el as HTMLElement)
-      setTimeout(() => {
-        el.style.height = '0px'
-      }, 1)
-    }
-
-    const handleAfterLeave = () => {
-      showClass.value = false
-    }
-
     return () =>
       h(
         props.as,
         {
-          class: ['nav-group', { show: showClass.value }],
+          class: ['nav-group', { show: visible.value }],
         },
         [
           slots.togglerContent &&
@@ -206,34 +195,17 @@ const CNavGroup = defineComponent({
               slots.togglerContent && slots.togglerContent()
             ),
           h(
-            Transition,
+            props.as === 'div' ? 'div' : 'ul',
             {
-              css: false,
-              onBeforeEnter: (el) => handleBeforeEnter(el),
-              onEnter: (el, done) => handleEnter(el, done),
-              onAfterEnter: (el) => handleAfterEnter(el),
-              onBeforeLeave: (el) => handleBeforeLeave(el),
-              onLeave: (el, done) => handleLeave(el, done),
-              onAfterLeave: () => handleAfterLeave(),
+              class: [
+                'nav-group-items',
+                {
+                  compact: props.compact,
+                },
+              ],
+              ref: navGroupItemsRef,
             },
-            {
-              default: () =>
-                withDirectives(
-                  h(
-                    props.as === 'div' ? 'div' : 'ul',
-                    {
-                      class: [
-                        'nav-group-items',
-                        {
-                          compact: props.compact,
-                        },
-                      ],
-                    },
-                    slots.default && slots.default()
-                  ),
-                  [[vShow, visible.value]]
-                ),
-            }
+            slots.default && slots.default()
           ),
         ]
       )

--- a/packages/coreui-vue/src/components/nav/CNavGroup.ts
+++ b/packages/coreui-vue/src/components/nav/CNavGroup.ts
@@ -1,4 +1,17 @@
-import { defineComponent, h, onMounted, ref, RendererElement, Transition, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  h,
+  inject,
+  onMounted,
+  provide,
+  Ref,
+  ref,
+  RendererElement,
+  Transition,
+  useId,
+  watch,
+} from 'vue'
 
 import { executeAfterTransition } from '../../utils/transition'
 
@@ -19,59 +32,84 @@ const CNavGroup = defineComponent({
     /**
      * Show nav group items.
      */
-    visible: Boolean,
+    visible: {
+      type: Boolean,
+      default: undefined,
+    },
   },
-  emits: ['visible-change'],
+  emits: ['update:visible', 'visible-change'],
   setup(props, { slots, emit }) {
-    const visible = ref()
-    const navGroupRef = ref()
-    const visibleGroup = ref()
+    const key = useId()
 
-    const handleVisibleChange = (visible: boolean, index: number) => {
-      if (visible) {
-        visibleGroup.value = index
-      } else {
-        if (visibleGroup.value === index) {
-          visibleGroup.value = 0
-        }
-      }
-    }
-
-    const isVisible = (index: number) => Boolean(visibleGroup.value === index)
-
-    onMounted(() => {
-      visible.value = props.visible
-      if (props.visible) {
-        navGroupRef.value.classList.add('show')
-      }
-
-      emit('visible-change', visible.value)
-    })
-
-    watch(
-      () => props.visible,
-      () => {
-        visible.value = props.visible
-
-        if (visible.value === false) {
-          visibleGroup.value = undefined
-        }
-      },
+    const parentActiveKey = inject<Ref<string | undefined> | undefined>(
+      'cNavGroupActiveKey',
+      undefined,
+    )
+    const parentSetActiveKey = inject<((key?: string) => void) | undefined>(
+      'cNavGroupSetActiveKey',
+      undefined,
     )
 
-    watch(visible, () => {
-      emit('visible-change', visible.value)
+    const internal = ref(Boolean(props.visible))
+
+    const visible = computed(() => {
+      if (props.visible !== undefined) {
+        return props.visible
+      }
+
+      if (parentActiveKey) {
+        return parentActiveKey.value === key
+      }
+
+      return internal.value
+    })
+
+    const activeGroupKey = ref<string>()
+    provide('cNavGroupActiveKey', activeGroupKey)
+    provide('cNavGroupSetActiveKey', (value?: string) => {
+      activeGroupKey.value = value
+    })
+
+    const showClass = ref(visible.value)
+
+    onMounted(() => {
+      if (props.visible && parentSetActiveKey) {
+        parentSetActiveKey(key)
+      }
+    })
+
+    watch(visible, (value) => {
+      if (props.visible !== undefined && parentSetActiveKey) {
+        if (value) {
+          parentSetActiveKey(key)
+        } else if (parentActiveKey && parentActiveKey.value === key) {
+          parentSetActiveKey(undefined)
+        }
+      }
+
+      emit('visible-change', value)
     })
 
     const handleTogglerClick = (event: Event) => {
       event.preventDefault()
-      visible.value = !visible.value
-      emit('visible-change', visible.value)
+
+      const next = !visible.value
+      emit('update:visible', next)
+
+      if (props.visible !== undefined) {
+        return
+      }
+
+      if (parentActiveKey && parentSetActiveKey) {
+        parentSetActiveKey(next ? key : undefined)
+      } else {
+        internal.value = next
+      }
     }
 
     const handleBeforeEnter = (el: RendererElement) => {
       el.style.height = '0px'
-      navGroupRef.value.classList.add('show')
+      showClass.value = true
     }
 
     // eslint-disable-next-line unicorn/consistent-function-scoping
@@ -99,21 +137,21 @@ const CNavGroup = defineComponent({
     }
 
     const handleAfterLeave = () => {
-      navGroupRef.value.classList.remove('show')
+      showClass.value = false
     }
 
     return () =>
       h(
         props.as,
         {
-          class: 'nav-group',
-          ref: navGroupRef,
+          class: ['nav-group', { show: showClass.value }],
         },
         [
           slots.togglerContent &&
             h(
               'a',
               {
+                'aria-expanded': visible.value,
                 class: ['nav-link', 'nav-group-toggle'],
                 href: '#',
                 onClick: handleTogglerClick,
@@ -144,18 +182,7 @@ const CNavGroup = defineComponent({
                       },
                     ],
                   },
-                  slots.default &&
-                    slots.default().map((vnode, index) => {
-                      // @ts-expect-error name is defined in component
-                      if (vnode.type.name === 'CNavGroup') {
-                        return h(vnode, {
-                          onVisibleChange: (visible: boolean) =>
-                            handleVisibleChange(visible, index + 1),
-                          ...(visibleGroup.value && { visible: isVisible(index + 1) }),
-                        })
-                      }
-                      return vnode
-                    }),
+                  slots.default && slots.default(),
                 ),
             },
           ),

--- a/packages/coreui-vue/src/components/nav/CNavLink.ts
+++ b/packages/coreui-vue/src/components/nav/CNavLink.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, inject, onMounted, watch } from 'vue'
 
 import { CLink } from '../link/CLink'
 
@@ -26,6 +26,23 @@ const CNavLink = defineComponent({
     href: String,
   },
   setup(props, { slots }) {
+    const openBranch = inject<(() => void) | undefined>('cNavGroupOpenBranch', undefined)
+
+    onMounted(() => {
+      if (props.active && openBranch) {
+        openBranch()
+      }
+    })
+
+    watch(
+      () => props.active,
+      (active, previous) => {
+        if (active && !previous && openBranch) {
+          openBranch()
+        }
+      }
+    )
+
     return () =>
       h(
         CLink,
@@ -38,7 +55,7 @@ const CNavLink = defineComponent({
         },
         {
           default: () => slots.default && slots.default(),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
+++ b/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
@@ -1,5 +1,7 @@
 import { mount } from '@vue/test-utils'
-import { CNavGroup as Component } from '../../../index'
+import { h, nextTick } from 'vue'
+import { CNavGroup as Component, CNavGroup, CNavItem } from '../../../index'
+import { CSidebarNav } from '../../sidebar/CSidebarNav'
 
 const ComponentName = 'CNavGroup'
 
@@ -41,6 +43,7 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('a').attributes('aria-expanded')).toBe('true')
     expect(customWrapper.find('ul').classes('nav-group-items')).toBe(true)
     expect(customWrapper.find('ul').classes('compact')).toBe(true)
+    expect(customWrapper.find('ul').isVisible()).toBe(true)
     expect(customWrapper.classes('nav-group')).toBe(true)
   })
 })
@@ -51,20 +54,18 @@ describe(`${ComponentName} uncontrolled mode`, () => {
       slots: { togglerContent: 'togglerContent' },
     })
 
-    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
     expect(wrapper.emitted('visible-change')).toBeUndefined()
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
     expect(wrapper.emitted('update:visible')).toEqual([[true]])
     expect(wrapper.emitted('visible-change')).toEqual([[true]])
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
-    expect(wrapper.emitted('update:visible')).toEqual([[true], [false]])
-    expect(wrapper.emitted('visible-change')).toEqual([[true], [false]])
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
   })
 
   it('does not emit visible-change on mount', () => {
@@ -74,40 +75,161 @@ describe(`${ComponentName} uncontrolled mode`, () => {
 
     expect(wrapper.emitted('visible-change')).toBeUndefined()
   })
+
+  it('treats `visible` without a listener as default-open and stays toggleable', async () => {
+    const wrapper = mount(Component, {
+      propsData: { visible: true },
+      slots: { togglerContent: 'togglerContent' },
+    })
+
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
+
+    await wrapper.find('.nav-group-toggle').trigger('click')
+
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
+  })
+})
+
+describe(`${ComponentName} nested groups`, () => {
+  const nested = () =>
+    mount(CSidebarNav, {
+      slots: {
+        default: () => [
+          h(
+            CNavGroup,
+            {},
+            {
+              togglerContent: () => 'A',
+              default: () => [
+                h(
+                  CNavGroup,
+                  {},
+                  {
+                    togglerContent: () => 'B',
+                    default: () => [h(CNavItem, { href: '#' }, () => 'item')],
+                  }
+                ),
+              ],
+            }
+          ),
+        ],
+      },
+    })
+
+  it('renders and toggles per level', async () => {
+    const wrapper = nested()
+    const groupItems = (index: number) =>
+      wrapper.findAll('.nav-group')[index].find('.nav-group-items')
+
+    expect(groupItems(0).isVisible()).toBe(false)
+
+    await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
+    expect(groupItems(0).isVisible()).toBe(true)
+    expect(groupItems(1).isVisible()).toBe(false)
+
+    await wrapper.findAll('.nav-group-toggle')[1].trigger('click')
+    expect(groupItems(1).isVisible()).toBe(true)
+
+    await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
+    expect(groupItems(0).isVisible()).toBe(false)
+  })
+
+  it('opening one sibling closes the other (per-level accordion)', async () => {
+    const wrapper = mount(CSidebarNav, {
+      slots: {
+        default: () => [
+          h(
+            CNavGroup,
+            {},
+            {
+              togglerContent: () => 'A',
+              default: () => [h(CNavItem, { href: '#' }, () => 'itemA')],
+            }
+          ),
+          h(
+            CNavGroup,
+            {},
+            {
+              togglerContent: () => 'B',
+              default: () => [h(CNavItem, { href: '#' }, () => 'itemB')],
+            }
+          ),
+        ],
+      },
+    })
+    const items = (index: number) => wrapper.findAll('.nav-group')[index].find('.nav-group-items')
+
+    await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
+    expect(items(0).isVisible()).toBe(true)
+    expect(items(1).isVisible()).toBe(false)
+
+    await wrapper.findAll('.nav-group-toggle')[1].trigger('click')
+    expect(items(1).isVisible()).toBe(true)
+    expect(items(0).isVisible()).toBe(false)
+  })
+
+  it('an active nav link opens its ancestor groups', async () => {
+    const wrapper = mount(CSidebarNav, {
+      slots: {
+        default: () => [
+          h(
+            CNavGroup,
+            {},
+            {
+              togglerContent: () => 'A',
+              default: () => [
+                h(
+                  CNavGroup,
+                  {},
+                  {
+                    togglerContent: () => 'B',
+                    default: () => [h(CNavItem, { active: true, href: '#' }, () => 'item')],
+                  }
+                ),
+              ],
+            }
+          ),
+        ],
+      },
+    })
+    const items = (index: number) => wrapper.findAll('.nav-group')[index].find('.nav-group-items')
+
+    await nextTick()
+
+    expect(items(0).isVisible()).toBe(true)
+    expect(items(1).isVisible()).toBe(true)
+  })
 })
 
 describe(`${ComponentName} controlled mode`, () => {
-  it('keeps the group open when the parent rejects the collapse (#313)', async () => {
+  it('stays open when the parent rejects the collapse (#313)', async () => {
+    const onUpdate = jest.fn()
     const wrapper = mount(Component, {
-      propsData: { visible: true },
+      props: { visible: true, 'onUpdate:visible': onUpdate },
       slots: { togglerContent: 'togglerContent' },
     })
 
-    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
 
-    // Parent keeps `visible` at `true` (rejects the collapse).
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    // Intent is emitted, but internal state is not mutated.
-    expect(wrapper.emitted('update:visible')).toEqual([[false]])
-    expect(wrapper.emitted('visible-change')).toBeUndefined()
-    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
-    expect(wrapper.classes('show')).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(false)
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
   })
 
-  it('follows the prop and emits visible-change when the parent accepts (v-model)', async () => {
+  it('follows the prop when the parent accepts (v-model)', async () => {
+    const onUpdate = jest.fn()
     const wrapper = mount(Component, {
-      propsData: { visible: true },
+      props: { visible: true, 'onUpdate:visible': onUpdate },
       slots: { togglerContent: 'togglerContent' },
     })
 
     await wrapper.find('.nav-group-toggle').trigger('click')
-    expect(wrapper.emitted('update:visible')).toEqual([[false]])
+    expect(onUpdate).toHaveBeenCalledWith(false)
 
-    // Parent updates the prop in response (v-model).
     await wrapper.setProps({ visible: false })
 
-    expect(wrapper.emitted('visible-change')).toEqual([[false]])
-    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
+    expect(wrapper.emitted('visible-change')).toContainEqual([false])
+    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
   })
 })

--- a/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
+++ b/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
@@ -43,8 +43,8 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('a').attributes('aria-expanded')).toBe('true')
     expect(customWrapper.find('ul').classes('nav-group-items')).toBe(true)
     expect(customWrapper.find('ul').classes('compact')).toBe(true)
-    expect(customWrapper.find('ul').isVisible()).toBe(true)
     expect(customWrapper.classes('nav-group')).toBe(true)
+    expect(customWrapper.classes('show')).toBe(true)
   })
 })
 
@@ -54,18 +54,18 @@ describe(`${ComponentName} uncontrolled mode`, () => {
       slots: { togglerContent: 'togglerContent' },
     })
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
+    expect(wrapper.classes('show')).toBe(false)
     expect(wrapper.emitted('visible-change')).toBeUndefined()
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
+    expect(wrapper.classes('show')).toBe(true)
     expect(wrapper.emitted('update:visible')).toEqual([[true]])
     expect(wrapper.emitted('visible-change')).toEqual([[true]])
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
+    expect(wrapper.classes('show')).toBe(false)
   })
 
   it('does not emit visible-change on mount', () => {
@@ -82,11 +82,11 @@ describe(`${ComponentName} uncontrolled mode`, () => {
       slots: { togglerContent: 'togglerContent' },
     })
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
+    expect(wrapper.classes('show')).toBe(true)
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
+    expect(wrapper.classes('show')).toBe(false)
   })
 })
 
@@ -118,20 +118,19 @@ describe(`${ComponentName} nested groups`, () => {
 
   it('renders and toggles per level', async () => {
     const wrapper = nested()
-    const groupItems = (index: number) =>
-      wrapper.findAll('.nav-group')[index].find('.nav-group-items')
+    const group = (index: number) => wrapper.findAll('.nav-group')[index]
 
-    expect(groupItems(0).isVisible()).toBe(false)
+    expect(group(0).classes('show')).toBe(false)
 
     await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
-    expect(groupItems(0).isVisible()).toBe(true)
-    expect(groupItems(1).isVisible()).toBe(false)
+    expect(group(0).classes('show')).toBe(true)
+    expect(group(1).classes('show')).toBe(false)
 
     await wrapper.findAll('.nav-group-toggle')[1].trigger('click')
-    expect(groupItems(1).isVisible()).toBe(true)
+    expect(group(1).classes('show')).toBe(true)
 
     await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
-    expect(groupItems(0).isVisible()).toBe(false)
+    expect(group(0).classes('show')).toBe(false)
   })
 
   it('opening one sibling closes the other (per-level accordion)', async () => {
@@ -157,15 +156,15 @@ describe(`${ComponentName} nested groups`, () => {
         ],
       },
     })
-    const items = (index: number) => wrapper.findAll('.nav-group')[index].find('.nav-group-items')
+    const group = (index: number) => wrapper.findAll('.nav-group')[index]
 
     await wrapper.findAll('.nav-group-toggle')[0].trigger('click')
-    expect(items(0).isVisible()).toBe(true)
-    expect(items(1).isVisible()).toBe(false)
+    expect(group(0).classes('show')).toBe(true)
+    expect(group(1).classes('show')).toBe(false)
 
     await wrapper.findAll('.nav-group-toggle')[1].trigger('click')
-    expect(items(1).isVisible()).toBe(true)
-    expect(items(0).isVisible()).toBe(false)
+    expect(group(1).classes('show')).toBe(true)
+    expect(group(0).classes('show')).toBe(false)
   })
 
   it('an active nav link opens its ancestor groups', async () => {
@@ -192,12 +191,11 @@ describe(`${ComponentName} nested groups`, () => {
         ],
       },
     })
-    const items = (index: number) => wrapper.findAll('.nav-group')[index].find('.nav-group-items')
 
     await nextTick()
 
-    expect(items(0).isVisible()).toBe(true)
-    expect(items(1).isVisible()).toBe(true)
+    expect(wrapper.findAll('.nav-group')[0].classes('show')).toBe(true)
+    expect(wrapper.findAll('.nav-group')[1].classes('show')).toBe(true)
   })
 })
 
@@ -209,12 +207,12 @@ describe(`${ComponentName} controlled mode`, () => {
       slots: { togglerContent: 'togglerContent' },
     })
 
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
+    expect(wrapper.classes('show')).toBe(true)
 
     await wrapper.find('.nav-group-toggle').trigger('click')
 
     expect(onUpdate).toHaveBeenCalledWith(false)
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(true)
+    expect(wrapper.classes('show')).toBe(true)
   })
 
   it('follows the prop when the parent accepts (v-model)', async () => {
@@ -230,6 +228,6 @@ describe(`${ComponentName} controlled mode`, () => {
     await wrapper.setProps({ visible: false })
 
     expect(wrapper.emitted('visible-change')).toContainEqual([false])
-    expect(wrapper.find('.nav-group-items').isVisible()).toBe(false)
+    expect(wrapper.classes('show')).toBe(false)
   })
 })

--- a/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
+++ b/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
@@ -38,14 +38,76 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('a').text()).toContain('togglerContent')
     expect(customWrapper.find('a').classes('nav-link')).toBe(true)
     expect(customWrapper.find('a').classes('nav-group-toggle')).toBe(true)
+    expect(customWrapper.find('a').attributes('aria-expanded')).toBe('true')
     expect(customWrapper.find('ul').classes('nav-group-items')).toBe(true)
     expect(customWrapper.find('ul').classes('compact')).toBe(true)
     expect(customWrapper.classes('nav-group')).toBe(true)
   })
-  it('emit event visible-change on click nav-group-toggle', () => {
-    let incrementEvent = customWrapper.emitted('visible-change')
-    customWrapper.find('.nav-group-toggle').trigger('click')
-    incrementEvent = customWrapper.emitted('visible-change')
-    expect(incrementEvent).toHaveLength(3)
+})
+
+describe(`${ComponentName} uncontrolled mode`, () => {
+  it('toggles its own visibility and emits on actual change', async () => {
+    const wrapper = mount(Component, {
+      slots: { togglerContent: 'togglerContent' },
+    })
+
+    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
+    expect(wrapper.emitted('visible-change')).toBeUndefined()
+
+    await wrapper.find('.nav-group-toggle').trigger('click')
+
+    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
+    expect(wrapper.emitted('update:visible')).toEqual([[true]])
+    expect(wrapper.emitted('visible-change')).toEqual([[true]])
+
+    await wrapper.find('.nav-group-toggle').trigger('click')
+
+    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
+    expect(wrapper.emitted('update:visible')).toEqual([[true], [false]])
+    expect(wrapper.emitted('visible-change')).toEqual([[true], [false]])
+  })
+
+  it('does not emit visible-change on mount', () => {
+    const wrapper = mount(Component, {
+      slots: { togglerContent: 'togglerContent' },
+    })
+
+    expect(wrapper.emitted('visible-change')).toBeUndefined()
+  })
+})
+
+describe(`${ComponentName} controlled mode`, () => {
+  it('keeps the group open when the parent rejects the collapse (#313)', async () => {
+    const wrapper = mount(Component, {
+      propsData: { visible: true },
+      slots: { togglerContent: 'togglerContent' },
+    })
+
+    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
+
+    // Parent keeps `visible` at `true` (rejects the collapse).
+    await wrapper.find('.nav-group-toggle').trigger('click')
+
+    // Intent is emitted, but internal state is not mutated.
+    expect(wrapper.emitted('update:visible')).toEqual([[false]])
+    expect(wrapper.emitted('visible-change')).toBeUndefined()
+    expect(wrapper.find('.nav-group-items').exists()).toBe(true)
+    expect(wrapper.classes('show')).toBe(true)
+  })
+
+  it('follows the prop and emits visible-change when the parent accepts (v-model)', async () => {
+    const wrapper = mount(Component, {
+      propsData: { visible: true },
+      slots: { togglerContent: 'togglerContent' },
+    })
+
+    await wrapper.find('.nav-group-toggle').trigger('click')
+    expect(wrapper.emitted('update:visible')).toEqual([[false]])
+
+    // Parent updates the prop in response (v-model).
+    await wrapper.setProps({ visible: false })
+
+    expect(wrapper.emitted('visible-change')).toEqual([[false]])
+    expect(wrapper.find('.nav-group-items').exists()).toBe(false)
   })
 })

--- a/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
+++ b/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Customize CNavGroup component renders correctly 1`] = `
-"<li class="nav-group show"><a class="nav-link nav-group-toggle">togglerContent</a>
+"<li class="nav-group show"><a aria-expanded="true" class="nav-link nav-group-toggle" href="#">togglerContent</a>
   <transition-stub appear="false" persisted="false" css="false">
     <ul class="nav-group-items compact"></ul>
   </transition-stub>

--- a/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
+++ b/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
@@ -2,17 +2,13 @@
 
 exports[`Customize CNavGroup component renders correctly 1`] = `
 "<li class="nav-group show"><a aria-expanded="true" class="nav-link nav-group-toggle" href="#">togglerContent</a>
-  <transition-stub appear="false" persisted="false" css="false">
-    <ul class="nav-group-items compact"></ul>
-  </transition-stub>
+  <ul class="nav-group-items compact"></ul>
 </li>"
 `;
 
 exports[`Loads and display CNavGroup component renders correctly 1`] = `
 "<li class="nav-group">
   <!---->
-  <transition-stub appear="false" persisted="false" css="false">
-    <ul class="nav-group-items" style="display: none;"></ul>
-  </transition-stub>
+  <ul class="nav-group-items"></ul>
 </li>"
 `;

--- a/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
+++ b/packages/coreui-vue/src/components/nav/__tests__/__snapshots__/CNavGroup.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`Loads and display CNavGroup component renders correctly 1`] = `
 "<li class="nav-group">
   <!---->
   <transition-stub appear="false" persisted="false" css="false">
-    <!---->
+    <ul class="nav-group-items" style="display: none;"></ul>
   </transition-stub>
 </li>"
 `;

--- a/packages/coreui-vue/src/components/sidebar/CSidebarNav.ts
+++ b/packages/coreui-vue/src/components/sidebar/CSidebarNav.ts
@@ -1,4 +1,4 @@
-import { Component, defineComponent, h, ref, PropType } from 'vue'
+import { Component, defineComponent, h, provide, ref, PropType } from 'vue'
 
 const CSidebarNav = defineComponent({
   name: 'CSidebarNav',
@@ -12,19 +12,11 @@ const CSidebarNav = defineComponent({
     },
   },
   setup(props, { slots }) {
-    const visibleGroup = ref()
-
-    const handleVisibleChange = (visible: boolean, index: number) => {
-      if (visible) {
-        visibleGroup.value = index
-      } else {
-        if (visibleGroup.value === index) {
-          visibleGroup.value = 0
-        }
-      }
-    }
-
-    const isVisible = (index: number) => Boolean(visibleGroup.value === index)
+    const activeGroupKey = ref<string>()
+    provide('cNavGroupActiveKey', activeGroupKey)
+    provide('cNavGroupSetActiveKey', (value?: string) => {
+      activeGroupKey.value = value
+    })
 
     return () =>
       h(
@@ -33,18 +25,7 @@ const CSidebarNav = defineComponent({
           class: 'sidebar-nav',
         },
         {
-          default: () =>
-            slots.default &&
-            slots.default().map((vnode, index) => {
-              // @ts-expect-error name is defined in component
-              if (vnode.type.name === 'CNavGroup') {
-                return h(vnode, {
-                  onVisibleChange: (visible: boolean) => handleVisibleChange(visible, index + 1),
-                  ...(visibleGroup.value && { visible: isVisible(index + 1) }),
-                })
-              }
-              return vnode
-            }),
+          default: () => slots.default && slots.default(),
         },
       )
   },

--- a/packages/docs/api/nav/CNavGroup.api.md
+++ b/packages/docs/api/nav/CNavGroup.api.md
@@ -18,4 +18,5 @@ import CNavGroup from '@coreui/vue/src/components/nav/CNavGroup'
 
 | Event name         | Description | Properties |
 | ------------------ | ----------- | ---------- |
+| **update:visible** |             |
 | **visible-change** |             |

--- a/packages/docs/api/nav/CNavGroup.api.md
+++ b/packages/docs/api/nav/CNavGroup.api.md
@@ -8,11 +8,11 @@ import CNavGroup from '@coreui/vue/src/components/nav/CNavGroup'
 
 #### Props
 
-| Prop name   | Description                                                                             | Type    | Values | Default |
-| ----------- | --------------------------------------------------------------------------------------- | ------- | ------ | ------- |
-| **as**      | Component used for the root node. Either a string to use a HTML element or a component. | string  | -      | 'li'    |
-| **compact** | Make nav group more compact by cutting all `padding` in half.                           | boolean | -      | -       |
-| **visible** | Show nav group items.                                                                   | boolean | -      | -       |
+| Prop name   | Description                                                                                                                                                  | Type    | Values | Default |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------ | ------- |
+| **as**      | Component used for the root node. Either a string to use a HTML element or a component.                                                                      | string  | -      | 'li'    |
+| **compact** | Make nav group more compact by cutting all `padding` in half.                                                                                                | boolean | -      | -       |
+| **visible** | Show nav group items. Acts as the initial state on its own, or as the controlled value<br>when paired with a `v-model:visible` / `@update:visible` listener. | boolean | -      | -       |
 
 #### Events
 

--- a/packages/docs/code-examples/sidebar/SidebarNavGroupControlledExample.vue
+++ b/packages/docs/code-examples/sidebar/SidebarNavGroupControlledExample.vue
@@ -1,0 +1,60 @@
+<template>
+  <CSidebar class="border-end">
+    <CSidebarHeader class="border-bottom">
+      <CSidebarBrand>CoreUI</CSidebarBrand>
+    </CSidebarHeader>
+    <CSidebarNav>
+      <CNavTitle>Nav Title</CNavTitle>
+      <CNavItem href="#">
+        <CIcon customClassName="nav-icon" :icon="cilSpeedometer" /> Dashboard
+      </CNavItem>
+      <CNavGroup :visible="visible" @update:visible="handleVisibleChange">
+        <template #togglerContent>
+          <CIcon customClassName="nav-icon" :icon="cilPuzzle" /> Active section
+        </template>
+        <CNavItem href="#">
+          <span class="nav-icon"><span class="nav-icon-bullet"></span></span> Overview
+        </CNavItem>
+        <CNavItem href="#">
+          <span class="nav-icon"><span class="nav-icon-bullet"></span></span> Settings
+        </CNavItem>
+      </CNavGroup>
+      <CNavItem href="https://coreui.io">
+        <CIcon customClassName="nav-icon" :icon="cilCloudDownload" /> Download CoreUI
+      </CNavItem>
+    </CSidebarNav>
+    <CSidebarFooter class="border-top">
+      <CButton color="primary" size="sm" @click="locked = !locked">
+        {{ locked ? 'Unlock collapsing' : 'Lock the active section open' }}
+      </CButton>
+    </CSidebarFooter>
+  </CSidebar>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import {
+  CButton,
+  CNavGroup,
+  CNavItem,
+  CNavTitle,
+  CSidebar,
+  CSidebarBrand,
+  CSidebarFooter,
+  CSidebarHeader,
+  CSidebarNav,
+} from '@coreui/vue'
+import { CIcon } from '@coreui/icons-vue'
+import { cilCloudDownload, cilPuzzle, cilSpeedometer } from '@coreui/icons'
+
+const visible = ref(true)
+const locked = ref(true)
+
+const handleVisibleChange = (value) => {
+  if (!value && locked.value) {
+    return
+  }
+
+  visible.value = value
+}
+</script>

--- a/packages/docs/components/sidebar.md
+++ b/packages/docs/components/sidebar.md
@@ -262,6 +262,19 @@ Add the `unfoldable` property to make the sidebar narrow with unfoldable on hove
 </CSidebar>
 ```
 
+## Controlling nav group visibility
+
+<AddedIn version="5.9.0" />
+
+`<CNavGroup>` works uncontrolled by default—clicking the toggler expands and collapses it on its own. To control it from the parent, bind `visible` and listen to `update:visible` (or use `v-model:visible`). In controlled mode the toggler only requests a change through `update:visible`; the group's state follows the `visible` prop, so the parent has the final say.
+
+This makes it possible to keep a section open even when the user clicks to collapse it—useful for a route-aware sidebar that must keep the active section expanded. Toggle the lock below and try to collapse the group: while locked, the parent rejects the change and the group stays in sync with `visible`.
+
+::: demo-bg-secondary
+<SidebarNavGroupControlledExample />
+:::
+@[code vue](@example/sidebar/SidebarNavGroupControlledExample.vue)
+
 ## Dark sidebar
 
 Change the appearance of sidebars with the `colorScheme="dark"`.
@@ -407,3 +420,7 @@ return <CSidebar :style="vars">...</CSidebar>
 ## API
 
 !!!include(./api/sidebar/CSidebar.api.md)!!!
+
+<script setup>
+  import SidebarNavGroupControlledExample from '@example/sidebar/SidebarNavGroupControlledExample.vue'
+</script>


### PR DESCRIPTION
## Summary

Reworks `CNavGroup` state handling so the component works either **uncontrolled** (the toggler manages its own state) or **controlled** (the parent owns `visible`). Fixes the desync reported in #313.

### The bug (#313)

In controlled mode (`:visible` + `@visible-change`) the toggler mutated an internal `visible` ref **immediately**, before the parent could reject the collapse. When the parent kept `:visible="true"` (e.g. a route-aware sidebar that must keep the active section expanded), the prop never changed, so `watch(() => props.visible)` never ran and the internal state stayed collapsed — the group rendered collapsed while `props.visible` was still `true`, with no resync until remount.

### The fix

- **Tri-state `visible`** (`default: undefined`) so the component can tell controlled from uncontrolled usage.
- In **controlled mode the toggler no longer mutates internal state** — it only emits the requested value through the new **`update:visible`** event (enables `v-model:visible`). Visibility follows the prop, so rejecting a collapse simply keeps the group open. No desync.
- `visible-change` is kept as a notification fired on **actual** visibility changes (no more emit on mount / no triple emit).
- Nested-group accordion coordination now uses **provide/inject** (the existing `CAccordion` pattern) instead of cloning vnodes and sniffing `vnode.type.name`. This removes the duplicated logic in `CSidebarNav` and works through wrappers, `v-for` and `v-if`.
- `show` class is driven by a reactive ref (no imperative DOM mutation) and the toggler gets `aria-expanded`.

### Behavior notes

- `visible` default changes `false → undefined`. Uncontrolled groups still start closed; controlled usage is unchanged apart from the fix.
- The contradictory "static `:visible="true"` + collapse via the toggler" pattern no longer collapses — that was controlled usage without updating the prop (the #313 scenario with the opposite expectation). The docs never bind `:visible` on `CNavGroup`.
- Accordion coordination is preserved (including nested groups outside `CSidebarNav`); only the mechanism changed.

### Docs

Adds a "Controlling nav group visibility" example to the Sidebar page using the `code-examples` pattern, demonstrating a controlled group whose collapse can be rejected.

### Tests

Rewrites `CNavGroup.spec.ts`: uncontrolled toggle, controlled reject (#313 regression), `v-model` accept, and "no emit on mount". Snapshot updated.

Closes #313