### PR TITLE
chore(eslint): add vue-eslint-parser and apply lint autofixes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,9 +29,13 @@ export default typescriptEslint.config(
       'unicorn/filename-case': 'off',
       'unicorn/no-array-for-each': 'off',
       'unicorn/no-null': 'off',
+      'unicorn/no-useless-undefined': 'off',
+      'unicorn/prefer-at': 'off',
       'unicorn/prefer-dom-node-append': 'off',
       'unicorn/prefer-export-from': 'off',
+      'unicorn/prefer-global-this': 'off',
       'unicorn/prefer-query-selector': 'off',
+      'unicorn/prefer-spread': 'off',
       'unicorn/prevent-abbreviations': 'off',
       'vue/require-default-prop': 'off',
     },
@@ -72,5 +76,5 @@ export default typescriptEslint.config(
       strict: 'error',
     },
   },
-  eslintPluginPrettierRecommended,
+  eslintPluginPrettierRecommended
 )

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lerna": "^8.2.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.1",
-    "typescript-eslint": "^8.57.2"
+    "typescript-eslint": "^8.57.2",
+    "vue-eslint-parser": "^10.4.1"
   }
 }

--- a/packages/coreui-vue/src/components/accordion/CAccordion.ts
+++ b/packages/coreui-vue/src/components/accordion/CAccordion.ts
@@ -24,7 +24,7 @@ const CAccordion = defineComponent({
 
     watch(
       () => props.activeItemKey,
-      (value) => (activeItemKey.value = value),
+      (value) => (activeItemKey.value = value)
     )
 
     provide('activeItemKey', activeItemKey)
@@ -35,7 +35,7 @@ const CAccordion = defineComponent({
       h(
         'div',
         { class: ['accordion', { ['accordion-flush']: props.flush }] },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/accordion/CAccordionBody.ts
+++ b/packages/coreui-vue/src/components/accordion/CAccordionBody.ts
@@ -12,7 +12,7 @@ const CAccordionBody = defineComponent({
         { class: 'accordion-collapse', id, visible: visible.value },
         {
           default: () => h('div', { class: ['accordion-body'] }, slots.default && slots.default()),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/accordion/CAccordionButton.ts
+++ b/packages/coreui-vue/src/components/accordion/CAccordionButton.ts
@@ -17,7 +17,7 @@ const CAccordionButton = defineComponent({
           class: ['accordion-button', { ['collapsed']: !visible.value }],
           onClick: () => toggleVisibility(),
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/accordion/CAccordionHeader.ts
+++ b/packages/coreui-vue/src/components/accordion/CAccordionHeader.ts
@@ -13,8 +13,8 @@ const CAccordionHeader = defineComponent({
           {},
           {
             default: () => slots.default && slots.default(),
-          },
-        ),
+          }
+        )
       )
   },
 })

--- a/packages/coreui-vue/src/components/alert/CAlert.ts
+++ b/packages/coreui-vue/src/components/alert/CAlert.ts
@@ -49,7 +49,7 @@ export const CAlert = defineComponent({
       () => props.visible,
       () => {
         visible.value = props.visible
-      },
+      }
     )
 
     const handleDismiss = () => {
@@ -91,9 +91,9 @@ export const CAlert = defineComponent({
                       handleDismiss()
                     },
                   }),
-              ],
+              ]
             ),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/alert/CAlertHeading.ts
+++ b/packages/coreui-vue/src/components/alert/CAlertHeading.ts
@@ -18,7 +18,7 @@ export const CAlertHeading = defineComponent({
         {
           class: 'alert-heading',
         },
-        slots,
+        slots
       )
   },
 })

--- a/packages/coreui-vue/src/components/alert/CAlertLink.ts
+++ b/packages/coreui-vue/src/components/alert/CAlertLink.ts
@@ -9,7 +9,7 @@ export const CAlertLink = defineComponent({
         {
           class: 'alert-link',
         },
-        slots,
+        slots
       )
   },
 })

--- a/packages/coreui-vue/src/components/avatar/CAvatar.ts
+++ b/packages/coreui-vue/src/components/avatar/CAvatar.ts
@@ -79,7 +79,7 @@ const CAvatar = defineComponent({
             ? h('img', { src: props.src, class: 'avatar-img' })
             : slots.default && slots.default(),
           props.status && h('span', { class: ['avatar-status', `bg-${props.status}`] }),
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/backdrop/CBackdrop.ts
+++ b/packages/coreui-vue/src/components/backdrop/CBackdrop.ts
@@ -27,7 +27,7 @@ const CBackdrop = defineComponent({
           props.visible &&
           h('div', {
             class: 'fade',
-          }),
+          })
       )
   },
 })

--- a/packages/coreui-vue/src/components/badge/CBadge.ts
+++ b/packages/coreui-vue/src/components/badge/CBadge.ts
@@ -81,7 +81,7 @@ const CBadge = defineComponent({
             props.shape,
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/breadcrumb/CBreadcrumb.ts
+++ b/packages/coreui-vue/src/components/breadcrumb/CBreadcrumb.ts
@@ -10,7 +10,7 @@ const CBreadcrumb = defineComponent({
         {
           'aria-label': 'breadcrumb',
         },
-        h('ol', { class: ['breadcrumb', attrs.class] }, slots.default && slots.default()),
+        h('ol', { class: ['breadcrumb', attrs.class] }, slots.default && slots.default())
       )
   },
 })

--- a/packages/coreui-vue/src/components/breadcrumb/CBreadcrumbItem.ts
+++ b/packages/coreui-vue/src/components/breadcrumb/CBreadcrumbItem.ts
@@ -28,7 +28,7 @@ const CBreadcrumbItem = defineComponent({
         },
         props.href
           ? h('a', { href: props.href }, slots.default && slots.default())
-          : slots.default && slots.default(),
+          : slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/button-group/CButtonGroup.ts
+++ b/packages/coreui-vue/src/components/button-group/CButtonGroup.ts
@@ -29,7 +29,7 @@ const CButtonGroup = defineComponent({
             { [`btn-group-${props.size}`]: props.size },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/button/CButton.ts
+++ b/packages/coreui-vue/src/components/button/CButton.ts
@@ -108,7 +108,7 @@ export const CButton = defineComponent({
           ...(component === 'button' && { type: props.type, disabled: props.disabled }),
           onClick: handleClick,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/callout/CCallout.ts
+++ b/packages/coreui-vue/src/components/callout/CCallout.ts
@@ -24,7 +24,7 @@ const CCallout = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/card/CCard.ts
+++ b/packages/coreui-vue/src/components/card/CCard.ts
@@ -39,7 +39,7 @@ const CCard = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/card/CCardImage.ts
+++ b/packages/coreui-vue/src/components/card/CCardImage.ts
@@ -29,7 +29,7 @@ const CCardImage = defineComponent({
         {
           class: `card-img${props.orientation ? `-${props.orientation}` : ''}`,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/card/CCardLink.ts
+++ b/packages/coreui-vue/src/components/card/CCardLink.ts
@@ -17,7 +17,7 @@ const CCardLink = defineComponent({
       h(
         CLink,
         { class: 'card-link', href: props.href },
-        { default: () => slots.default && slots.default() },
+        { default: () => slots.default && slots.default() }
       )
   },
 })

--- a/packages/coreui-vue/src/components/carousel/CCarousel.ts
+++ b/packages/coreui-vue/src/components/carousel/CCarousel.ts
@@ -99,7 +99,7 @@ const CCarousel = defineComponent({
       if (typeof props.interval === 'number') {
         timeout.value = setTimeout(
           () => nextItemWhenVisible(),
-          typeof customInterval.value === 'number' ? customInterval.value : props.interval,
+          typeof customInterval.value === 'number' ? customInterval.value : props.interval
         )
       }
     }
@@ -206,7 +206,7 @@ const CCarousel = defineComponent({
                   ...(active.value === index && { class: 'active' }),
                   onClick: () => handleIndicatorClick(index),
                 })
-              }),
+              })
             ),
           h(
             'div',
@@ -216,7 +216,7 @@ const CCarousel = defineComponent({
                 active: active.value === index ? true : false,
                 direction: direction.value,
               })
-            }),
+            })
           ),
           props.controls && [
             h(
@@ -230,7 +230,7 @@ const CCarousel = defineComponent({
               [
                 h('span', { class: 'carousel-control-prev-icon', ariaHidden: 'true' }),
                 h('span', { class: 'visually-hidden' }, 'Previous'),
-              ],
+              ]
             ),
             h(
               'button',
@@ -243,10 +243,10 @@ const CCarousel = defineComponent({
               [
                 h('span', { class: 'carousel-control-next-icon', ariaHidden: 'true' }),
                 h('span', { class: 'visually-hidden' }, 'Next'),
-              ],
+              ]
             ),
           ],
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/carousel/CCarouselCaption.ts
+++ b/packages/coreui-vue/src/components/carousel/CCarouselCaption.ts
@@ -9,7 +9,7 @@ const CCarouselCaption = defineComponent({
         {
           class: 'carousel-caption',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/carousel/CCarouselItem.ts
+++ b/packages/coreui-vue/src/components/carousel/CCarouselItem.ts
@@ -32,9 +32,8 @@ const CCarouselItem = defineComponent({
     const orderClassName = ref()
     const activeClassName = ref(active.value && 'active')
 
-    // eslint-disable-next-line no-unused-vars
     const setAnimating = inject('setAnimating') as (value: boolean) => void
-    // eslint-disable-next-line no-unused-vars
+
     const setCustomInterval = inject('setCustomInterval') as (value: boolean | number) => void
 
     watch(active, (active, prevActive) => {
@@ -82,7 +81,7 @@ const CCarouselItem = defineComponent({
           ],
           ref: carouselItemRef,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/chip-input/CChipInput.ts
+++ b/packages/coreui-vue/src/components/chip-input/CChipInput.ts
@@ -47,7 +47,7 @@ const uniqueValues = (values: string[]): string[] => [
 
 const resolveChipClassName = (
   chipClassName: ChipClassName | undefined,
-  value: string,
+  value: string
 ): string | undefined => {
   if (!chipClassName) {
     return undefined
@@ -198,17 +198,17 @@ const CChipInput = defineComponent({
   setup(props, { attrs, emit, expose, slots }) {
     const internalValues = ref<string[]>(
       uniqueValues(
-        props.defaultValue.length > 0 ? props.defaultValue : valuesFromSlot(slots.default?.()),
-      ),
+        props.defaultValue.length > 0 ? props.defaultValue : valuesFromSlot(slots.default?.())
+      )
     )
     const inputValue = ref('')
     const inputRef = ref<HTMLInputElement>()
     const generatedName = useId()
 
     const values = computed(() =>
-      props.modelValue !== undefined
-        ? uniqueValues(props.modelValue as string[])
-        : uniqueValues(internalValues.value)
+      props.modelValue === undefined
+        ? uniqueValues(internalValues.value)
+        : uniqueValues(props.modelValue as string[])
     )
 
     // CChipInput builds on the same engine as CChipSet: useChipSet owns selection
@@ -240,7 +240,7 @@ const CChipInput = defineComponent({
     }
 
     const canAddMore = computed(
-      () => props.maxChips === null || values.value.length < props.maxChips,
+      () => props.maxChips === null || values.value.length < props.maxChips
     )
 
     const add = (rawValue: string): boolean => {
@@ -339,13 +339,14 @@ const CChipInput = defineComponent({
         const parts = value.split(props.separator)
         const chipsToAdd = uniqueValues(parts.slice(0, -1))
 
-        const newChips = chipsToAdd.filter(chip => !values.value.includes(chip))
-        const availableSlots = props.maxChips !== null ? props.maxChips - values.value.length : Infinity
+        const newChips = chipsToAdd.filter((chip) => !values.value.includes(chip))
+        const availableSlots =
+          props.maxChips === null ? Infinity : props.maxChips - values.value.length
         const chipsToEmit = newChips.slice(0, availableSlots)
 
         if (chipsToEmit.length > 0) {
           const nextValues = [...values.value, ...chipsToEmit]
-          chipsToEmit.forEach(chip => emit('add', chip))
+          chipsToEmit.forEach((chip) => emit('add', chip))
           emitValuesChange(nextValues)
         }
 
@@ -372,13 +373,14 @@ const CChipInput = defineComponent({
       event.preventDefault()
       const chipsToAdd = uniqueValues(pastedData.split(props.separator))
 
-      const newChips = chipsToAdd.filter(chip => !values.value.includes(chip))
-      const availableSlots = props.maxChips !== null ? props.maxChips - values.value.length : Infinity
+      const newChips = chipsToAdd.filter((chip) => !values.value.includes(chip))
+      const availableSlots =
+        props.maxChips === null ? Infinity : props.maxChips - values.value.length
       const chipsToEmit = newChips.slice(0, availableSlots)
 
       if (chipsToEmit.length > 0) {
         const nextValues = [...values.value, ...chipsToEmit]
-        chipsToEmit.forEach(chip => emit('add', chip))
+        chipsToEmit.forEach((chip) => emit('add', chip))
         emitValuesChange(nextValues)
       }
 
@@ -442,7 +444,7 @@ const CChipInput = defineComponent({
               class: 'chip-input-label',
               for: props.id,
             },
-            props.label,
+            props.label
           ),
         ...chipsFromData(
           values.value.map((chipValue) => ({
@@ -450,7 +452,7 @@ const CChipInput = defineComponent({
             label: chipValue,
             ariaRemoveLabel: `Remove ${chipValue}`,
             class: resolveChipClassName(props.chipClassName, chipValue),
-          })),
+          }))
         ),
         h('input', {
           ref: inputRef,
@@ -492,7 +494,7 @@ const CChipInput = defineComponent({
           onClick: handleContainerClick,
           onKeydown: handleContainerKeydown,
         },
-        children,
+        children
       )
     }
   },

--- a/packages/coreui-vue/src/components/chip-set/CChipSet.ts
+++ b/packages/coreui-vue/src/components/chip-set/CChipSet.ts
@@ -114,7 +114,7 @@ const CChipSet = defineComponent({
         if (props.chips) {
           emit(
             'update:chips',
-            props.chips.filter((item) => itemValue(item) !== value),
+            props.chips.filter((item) => itemValue(item) !== value)
           )
         }
         emit('remove', value)
@@ -132,7 +132,7 @@ const CChipSet = defineComponent({
           ...(props.disabled && { 'aria-disabled': true }),
           onKeydown: handleKeydown,
         },
-        props.chips ? chipsFromData(props.chips) : slots.default && slots.default(),
+        props.chips ? chipsFromData(props.chips) : slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/chip-set/__tests__/CChipSet.spec.ts
+++ b/packages/coreui-vue/src/components/chip-set/__tests__/CChipSet.spec.ts
@@ -6,7 +6,9 @@ import { CChip } from '../../chip/CChip'
 const set = (props: Record<string, unknown>, values: string[]) =>
   mount(CChipSet, {
     props,
-    slots: { default: () => values.map((v) => h(CChip, { value: v, key: v }, { default: () => v })) },
+    slots: {
+      default: () => values.map((v) => h(CChip, { value: v, key: v }, { default: () => v })),
+    },
   })
 
 describe('CChipSet', () => {
@@ -129,7 +131,11 @@ describe('CChipSet', () => {
       attachTo: document.body,
       props: {
         selectable: true,
-        chips: ['react', { value: 'vue', label: 'Vue' }, { value: 'ng', label: 'Angular', selectable: false }],
+        chips: [
+          'react',
+          { value: 'vue', label: 'Vue' },
+          { value: 'ng', label: 'Angular', selectable: false },
+        ],
       },
     })
     expect(w.findAll('.chip')).toHaveLength(3)

--- a/packages/coreui-vue/src/components/chip/CChip.ts
+++ b/packages/coreui-vue/src/components/chip/CChip.ts
@@ -165,8 +165,8 @@ const CChip = defineComponent({
     const isFilter = computed(() => Boolean(props.filter ?? config('filter')))
     const isRemovable = computed(() => Boolean(props.removable ?? config('removable')))
     // A filter chip is selectable by definition.
-    const isSelectable = computed(
-      () => Boolean((props.selectable ?? config('selectable')) || isFilter.value),
+    const isSelectable = computed(() =>
+      Boolean((props.selectable ?? config('selectable')) || isFilter.value)
     )
     const removeIcon = computed(() => props.removeIcon ?? config('removeIcon'))
     const selectedIcon = computed(() => props.selectedIcon ?? config('selectedIcon'))
@@ -178,11 +178,11 @@ const CChip = defineComponent({
       if (coordinated.value) {
         return chipSet!.isSelected(props.value as string)
       }
-      return props.selected !== undefined ? Boolean(props.selected) : internalSelected.value
+      return props.selected === undefined ? internalSelected.value : Boolean(props.selected)
     })
 
-    const isFocusable = computed(
-      () => Boolean(!isDisabled.value && (isSelectable.value || isRemovable.value)),
+    const isFocusable = computed(() =>
+      Boolean(!isDisabled.value && (isSelectable.value || isRemovable.value))
     )
 
     const setSelectableState = (nextSelected: boolean, event: MouseEvent | KeyboardEvent): void => {
@@ -288,10 +288,7 @@ const CChip = defineComponent({
             'stroke-width': 2,
             'stroke-linecap': 'round',
           },
-          [
-            h('line', { x1: 4, y1: 4, x2: 12, y2: 12 }),
-            h('line', { x1: 12, y1: 4, x2: 4, y2: 12 }),
-          ],
+          [h('line', { x1: 4, y1: 4, x2: 12, y2: 12 }), h('line', { x1: 12, y1: 4, x2: 4, y2: 12 })]
         )
 
       const selectedIconVNode =
@@ -308,7 +305,7 @@ const CChip = defineComponent({
           },
           h('path', {
             d: 'M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z',
-          }),
+          })
         )
 
       const children = [
@@ -327,7 +324,7 @@ const CChip = defineComponent({
               onClick: handleRemoveClick,
               tabindex: -1,
             },
-            removeIconVNode as VNode,
+            removeIconVNode as VNode
           ),
       ].filter(Boolean)
 
@@ -355,7 +352,7 @@ const CChip = defineComponent({
           onKeydown: handleKeydown,
           ...(props.as === 'button' && { disabled: isDisabled.value }),
         },
-        children,
+        children
       )
     }
   },

--- a/packages/coreui-vue/src/components/collapse/CCollapse.ts
+++ b/packages/coreui-vue/src/components/collapse/CCollapse.ts
@@ -101,10 +101,10 @@ const CCollapse = defineComponent({
                   { 'collapse-horizontal': props.horizontal, show: show.value },
                 ],
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
-            [[vVisible, props.visible]],
-          ),
+            [[vVisible, props.visible]]
+          )
       )
   },
 })

--- a/packages/coreui-vue/src/components/conditional-teleport/CConditionalTeleport.ts
+++ b/packages/coreui-vue/src/components/conditional-teleport/CConditionalTeleport.ts
@@ -1,7 +1,7 @@
 import { defineComponent, h, PropType, ref, Teleport, watch } from 'vue'
 
 const getContainer = (
-  container?: HTMLElement | (() => HTMLElement) | string,
+  container?: HTMLElement | (() => HTMLElement) | string
 ): HTMLElement | string => {
   if (container) {
     return typeof container === 'function' ? container() : container
@@ -39,7 +39,7 @@ const CConditionalTeleport = defineComponent({
         if (props.teleport) {
           container.value = getContainer(props.container)
         }
-      },
+      }
     )
 
     return () =>
@@ -51,7 +51,7 @@ const CConditionalTeleport = defineComponent({
         },
         {
           default: () => slots.default && slots.default(),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/dropdown/CDropdownHeader.ts
+++ b/packages/coreui-vue/src/components/dropdown/CDropdownHeader.ts
@@ -18,7 +18,7 @@ const CDropdownHeader = defineComponent({
         {
           class: 'dropdown-header',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/dropdown/CDropdownItem.ts
+++ b/packages/coreui-vue/src/components/dropdown/CDropdownItem.ts
@@ -38,7 +38,7 @@ const CDropdownItem = defineComponent({
         },
         {
           default: () => slots.default && slots.default(),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/dropdown/CDropdownMenu.ts
+++ b/packages/coreui-vue/src/components/dropdown/CDropdownMenu.ts
@@ -51,9 +51,9 @@ const CDropdownMenu = defineComponent({
               },
               props.as === 'ul'
                 ? slots.default && slots.default().map((vnode) => h('li', {}, vnode))
-                : slots.default && slots.default(),
+                : slots.default && slots.default()
             ),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/dropdown/CDropdownToggle.ts
+++ b/packages/coreui-vue/src/components/dropdown/CDropdownToggle.ts
@@ -142,7 +142,7 @@ const CDropdownToggle = defineComponent({
           event.preventDefault()
           setVisible(true, event)
         }
-      }
+      },
     }
 
     const togglerProps = computed(() => {
@@ -174,7 +174,7 @@ const CDropdownToggle = defineComponent({
                 togglerRef.value = el
               },
               ...triggers,
-            }),
+            })
           )
         : dropdownVariant === 'nav-item' && props.navLink
           ? h(
@@ -185,7 +185,7 @@ const CDropdownToggle = defineComponent({
                 role: 'button',
                 ref: dropdownToggleRef,
               },
-              { default: () => slots.default && slots.default() },
+              { default: () => slots.default && slots.default() }
             )
           : h(
               CButton,
@@ -204,7 +204,7 @@ const CDropdownToggle = defineComponent({
               () =>
                 props.split
                   ? h('span', { class: 'visually-hidden' }, props.splitLabel)
-                  : slots.default && slots.default(),
+                  : slots.default && slots.default()
             )
   },
 })

--- a/packages/coreui-vue/src/components/dropdown/utils.ts
+++ b/packages/coreui-vue/src/components/dropdown/utils.ts
@@ -8,7 +8,7 @@ export const getAlignmentClassNames = (alignment: Alignments) => {
   if (typeof alignment === 'object') {
     for (const key in alignment) {
       classNames.push(
-        `dropdown-menu${key === 'xs' ? '' : `-${key}`}-${alignment[key as keyof Breakpoints]}`,
+        `dropdown-menu${key === 'xs' ? '' : `-${key}`}-${alignment[key as keyof Breakpoints]}`
       )
     }
   }
@@ -24,7 +24,7 @@ export const getPlacement = (
   placement: Placement,
   direction: string | undefined,
   alignment: Alignments | string | undefined,
-  isRTL: boolean,
+  isRTL: boolean
 ): Placements => {
   let _placement = placement
 

--- a/packages/coreui-vue/src/components/focus-trap/CFocusTrap.ts
+++ b/packages/coreui-vue/src/components/focus-trap/CFocusTrap.ts
@@ -282,9 +282,9 @@ const CFocusTrap = defineComponent({
       const vnodes = slots.default?.()
       const vnode = vnodes?.[0]
       if (!vnode) return null
-    
+
       const originalRef = (vnode.props as any)?.ref
-    
+
       return cloneVNode(vnode, {
         ref: (el) => {
           // `el` may be a component public instance (e.g. when the trapped node is wrapped in a

--- a/packages/coreui-vue/src/components/footer/CFooter.ts
+++ b/packages/coreui-vue/src/components/footer/CFooter.ts
@@ -27,7 +27,7 @@ const CFooter = defineComponent({
       h(
         props.as,
         { class: ['footer', { [`footer-${props.position}`]: props.position }] },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CForm.ts
+++ b/packages/coreui-vue/src/components/form/CForm.ts
@@ -13,7 +13,7 @@ const CForm = defineComponent({
       h(
         'form',
         { class: [{ ['was-validated']: props.validated }] },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormCheck.ts
+++ b/packages/coreui-vue/src/components/form/CFormCheck.ts
@@ -135,7 +135,7 @@ const CFormCheck = defineComponent({
         if (props.modelValue.includes(props.value)) {
           emit(
             'update:modelValue',
-            props.modelValue.filter((value) => value !== props.value),
+            props.modelValue.filter((value) => value !== props.value)
           )
         } else {
           emit('update:modelValue', [...props.modelValue, props.value])
@@ -210,14 +210,14 @@ const CFormCheck = defineComponent({
             },
             {
               default: () => (slots.label && slots.label()) || props.label,
-            },
+            }
           )
         : h(
             CFormLabel,
             { class: 'form-check-label', ...(props.id && { for: props.id }) },
             {
               default: () => (slots.label && slots.label()) || props.label,
-            },
+            }
           )
 
     const formValidation = () => {
@@ -244,7 +244,7 @@ const CFormCheck = defineComponent({
                     customClassName: className,
                     ...(props.id && { for: props.id }),
                   },
-                  [formControl(), props.label],
+                  [formControl(), props.label]
                 ),
                 formValidation(),
               ]
@@ -253,7 +253,7 @@ const CFormCheck = defineComponent({
                 {
                   class: className,
                 },
-                [formControl(), props.label && formLabel(), formValidation()],
+                [formControl(), props.label && formLabel(), formValidation()]
               )
           : formControl()
   },

--- a/packages/coreui-vue/src/components/form/CFormControlValidation.ts
+++ b/packages/coreui-vue/src/components/form/CFormControlValidation.ts
@@ -56,7 +56,7 @@ const CFormControlValidation = defineComponent({
           },
           {
             default: () => (slots.feedback && slots.feedback()) || props.feedback,
-          },
+          }
         ),
       (props.feedbackInvalid || slots.feedbackInvalid) &&
         h(
@@ -69,7 +69,7 @@ const CFormControlValidation = defineComponent({
           {
             default: () =>
               (slots.feedbackInvalid && slots.feedbackInvalid()) || props.feedbackInvalid,
-          },
+          }
         ),
       (props.feedbackValid || slots.feedbackValid) &&
         h(
@@ -80,7 +80,7 @@ const CFormControlValidation = defineComponent({
           },
           {
             default: () => (slots.feedbackValid && slots.feedbackValid()) || props.feedbackValid,
-          },
+          }
         ),
     ]
   },

--- a/packages/coreui-vue/src/components/form/CFormControlWrapper.ts
+++ b/packages/coreui-vue/src/components/form/CFormControlWrapper.ts
@@ -71,7 +71,7 @@ const CFormControlWrapper = defineComponent({
           ...(slots.feedbackValid && {
             feedbackValid: () => slots.feedbackInvalid && slots.feedbackInvalid(),
           }),
-        },
+        }
       )
 
     return () =>
@@ -91,7 +91,7 @@ const CFormControlWrapper = defineComponent({
                 {
                   default: () =>
                     (slots.label && slots.label()) || props.label || props.floatingLabel,
-                },
+                }
               ),
               (props.text || slots.text) &&
                 h(
@@ -101,10 +101,10 @@ const CFormControlWrapper = defineComponent({
                   },
                   {
                     default: () => (slots.text && slots.text()) || props.text,
-                  },
+                  }
                 ),
               formControlValidation(),
-            ],
+            ]
           )
         : [
             (props.label || slots.label) &&
@@ -115,7 +115,7 @@ const CFormControlWrapper = defineComponent({
                 },
                 {
                   default: () => (slots.label && slots.label()) || props.label,
-                },
+                }
               ),
             slots.default && slots.default(),
             (props.text || slots.text) &&
@@ -126,7 +126,7 @@ const CFormControlWrapper = defineComponent({
                 },
                 {
                   default: () => (slots.text && slots.text()) || props.text,
-                },
+                }
               ),
             formControlValidation(),
           ]

--- a/packages/coreui-vue/src/components/form/CFormFeedback.ts
+++ b/packages/coreui-vue/src/components/form/CFormFeedback.ts
@@ -35,7 +35,7 @@ const CFormFeedback = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormFloating.ts
+++ b/packages/coreui-vue/src/components/form/CFormFloating.ts
@@ -9,7 +9,7 @@ const CFormFloating = defineComponent({
         {
           class: 'form-floating',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormInput.ts
+++ b/packages/coreui-vue/src/components/form/CFormInput.ts
@@ -168,7 +168,7 @@ const CFormInput = defineComponent({
                 type: props.type,
                 ...((props.modelValue || props.modelValue === 0) && { value: props.modelValue }),
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
           ...(slots.feedback && { feedback: () => slots.feedback && slots.feedback() }),
           ...(slots.feedbackInvalid && {
@@ -179,7 +179,7 @@ const CFormInput = defineComponent({
           }),
           ...(slots.label && { label: () => slots.label && slots.label() }),
           ...(slots.text && { text: () => slots.text && slots.text() }),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormLabel.ts
+++ b/packages/coreui-vue/src/components/form/CFormLabel.ts
@@ -15,7 +15,7 @@ const CFormLabel = defineComponent({
         {
           class: props.customClassName ?? 'form-label',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormRange.ts
+++ b/packages/coreui-vue/src/components/form/CFormRange.ts
@@ -67,7 +67,7 @@ const CFormRange = defineComponent({
           },
           {
             default: () => (slots.label && slots.label()) || props.label,
-          },
+          }
         ),
       h(
         'input',
@@ -83,7 +83,7 @@ const CFormRange = defineComponent({
           type: 'range',
           value: props.modelValue,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       ),
     ]
   },

--- a/packages/coreui-vue/src/components/form/CFormSelect.ts
+++ b/packages/coreui-vue/src/components/form/CFormSelect.ts
@@ -170,10 +170,10 @@ const CFormSelect = defineComponent({
                           }),
                         }),
                       },
-                      typeof option === 'string' ? option : option.label,
+                      typeof option === 'string' ? option : option.label
                     )
                   })
-                : slots.default && slots.default(),
+                : slots.default && slots.default()
             ),
           ...(slots.feedback && { feedback: () => slots.feedback && slots.feedback() }),
           ...(slots.feedbackInvalid && {
@@ -184,7 +184,7 @@ const CFormSelect = defineComponent({
           }),
           ...(slots.label && { label: () => slots.label && slots.label() }),
           ...(slots.text && { text: () => slots.text && slots.text() }),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormSwitch.ts
+++ b/packages/coreui-vue/src/components/form/CFormSwitch.ts
@@ -109,9 +109,9 @@ const CFormSwitch = defineComponent({
               },
               {
                 default: () => props.label,
-              },
+              }
             ),
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CFormTextarea.ts
+++ b/packages/coreui-vue/src/components/form/CFormTextarea.ts
@@ -141,7 +141,7 @@ const CFormTextarea = defineComponent({
                 onInput: (event: InputEvent) => handleInput(event),
                 ...(props.modelValue && { value: props.modelValue }),
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
           ...(slots.feedback && { feedback: () => slots.feedback && slots.feedback() }),
           ...(slots.feedbackInvalid && {
@@ -152,7 +152,7 @@ const CFormTextarea = defineComponent({
           }),
           ...(slots.label && { label: () => slots.label && slots.label() }),
           ...(slots.text && { text: () => slots.text && slots.text() }),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/form/CInputGroup.ts
+++ b/packages/coreui-vue/src/components/form/CInputGroup.ts
@@ -27,7 +27,7 @@ const CInputGroup = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/grid/CCol.ts
+++ b/packages/coreui-vue/src/components/grid/CCol.ts
@@ -114,7 +114,7 @@ const CCol = defineComponent({
         {
           class: [repsonsiveClassNames.length > 0 ? repsonsiveClassNames : 'col'],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/grid/CContainer.ts
+++ b/packages/coreui-vue/src/components/grid/CContainer.ts
@@ -51,7 +51,7 @@ const CContainer = defineComponent({
         {
           class: [repsonsiveClassNames.length > 0 ? repsonsiveClassNames : 'container'],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/grid/CRow.ts
+++ b/packages/coreui-vue/src/components/grid/CRow.ts
@@ -85,7 +85,7 @@ const CRow = defineComponent({
         {
           class: ['row', repsonsiveClassNames],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/header/CHeader.ts
+++ b/packages/coreui-vue/src/components/header/CHeader.ts
@@ -44,9 +44,9 @@ const CHeader = defineComponent({
           ? h(
               'div',
               { class: `container${props.container === true ? '' : '-' + props.container}` },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             )
-          : slots.default && slots.default(),
+          : slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/header/CHeaderNav.ts
+++ b/packages/coreui-vue/src/components/header/CHeaderNav.ts
@@ -19,7 +19,7 @@ const CHeaderNav = defineComponent({
           class: 'header-nav',
           role: 'navigation',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/header/CHeaderToggler.ts
+++ b/packages/coreui-vue/src/components/header/CHeaderToggler.ts
@@ -11,7 +11,7 @@ const CHeaderToggler = defineComponent({
           type: 'button',
           'aria-label': 'Toggle navigation',
         },
-        slots.default ? slots.default() : h('span', { class: ['header-toggler-icon'] }),
+        slots.default ? slots.default() : h('span', { class: ['header-toggler-icon'] })
       )
   },
 })

--- a/packages/coreui-vue/src/components/header/__tests__/CHeader.spec.ts
+++ b/packages/coreui-vue/src/components/header/__tests__/CHeader.spec.ts
@@ -54,7 +54,6 @@ describe(`Customize ${ComponentName} component`, () => {
   })
 })
 
-
 describe(`Customize (number two) ${ComponentName} component`, () => {
   it('renders correctly', () => {
     expect(customWrapperTwo.html()).toMatchSnapshot()

--- a/packages/coreui-vue/src/components/link/CLink.ts
+++ b/packages/coreui-vue/src/components/link/CLink.ts
@@ -49,7 +49,7 @@ const CLink = defineComponent({
           }),
           href: props.href,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/list-group/CListGroup.ts
+++ b/packages/coreui-vue/src/components/list-group/CListGroup.ts
@@ -46,7 +46,7 @@ const CListGroup = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/list-group/CListGroupItem.ts
+++ b/packages/coreui-vue/src/components/list-group/CListGroupItem.ts
@@ -48,7 +48,7 @@ const CListGroupItem = defineComponent({
           ...(props.active && { 'aria-current': true }),
           ...(props.disabled && { 'aria-disabled': true }),
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/modal/CModal.ts
+++ b/packages/coreui-vue/src/components/modal/CModal.ts
@@ -186,7 +186,6 @@ const CModal = defineComponent({
       window.addEventListener('keydown', handleKeyDown)
     }
 
-    // eslint-disable-next-line unicorn/consistent-function-scoping
     const handleLeave = (el: RendererElement, done: () => void) => {
       executeAfterTransition(() => done(), el as HTMLElement)
       document.body.classList.remove('modal-open')

--- a/packages/coreui-vue/src/components/modal/CModalHeader.ts
+++ b/packages/coreui-vue/src/components/modal/CModalHeader.ts
@@ -18,9 +18,16 @@ const CModalHeader = defineComponent({
     return () =>
       h('span', { class: 'modal-header' }, [
         slots.default && slots.default(),
-        props.closeButton && h(CCloseButton, { onClick: () => {
-          visible.value = false
-        } }, ''),
+        props.closeButton &&
+          h(
+            CCloseButton,
+            {
+              onClick: () => {
+                visible.value = false
+              },
+            },
+            ''
+          ),
       ])
   },
 })

--- a/packages/coreui-vue/src/components/nav/CNav.ts
+++ b/packages/coreui-vue/src/components/nav/CNav.ts
@@ -29,7 +29,14 @@ const CNav = defineComponent({
     variant: {
       type: String,
       validator: (value: string) => {
-        return ['enclosed', 'enclosed-pills', 'pills', 'tabs', 'underline', 'underline-border'].includes(value)
+        return [
+          'enclosed',
+          'enclosed-pills',
+          'pills',
+          'tabs',
+          'underline',
+          'underline-border',
+        ].includes(value)
       },
     },
   },
@@ -48,7 +55,7 @@ const CNav = defineComponent({
           ],
           role: 'navigation',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/nav/CNavItem.ts
+++ b/packages/coreui-vue/src/components/nav/CNavItem.ts
@@ -54,9 +54,9 @@ const CNavItem = defineComponent({
               },
               {
                 default: () => slots.default && slots.default(),
-              },
+              }
             )
-          : slots.default && slots.default(),
+          : slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/navbar/CNavbar.ts
+++ b/packages/coreui-vue/src/components/navbar/CNavbar.ts
@@ -86,9 +86,9 @@ const CNavbar = defineComponent({
           ? h(
               'div',
               { class: [`container${props.container === true ? '' : '-' + props.container}`] },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             )
-          : slots.default && slots.default(),
+          : slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/navbar/CNavbarBrand.ts
+++ b/packages/coreui-vue/src/components/navbar/CNavbarBrand.ts
@@ -24,7 +24,7 @@ const CNavbarBrand = defineComponent({
           class: 'navbar-brand',
           href: props.href,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/navbar/CNavbarNav.ts
+++ b/packages/coreui-vue/src/components/navbar/CNavbarNav.ts
@@ -19,7 +19,7 @@ const CNavbarNav = defineComponent({
           class: 'navbar-nav',
           role: 'navigation',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/navbar/CNavbarToggler.ts
+++ b/packages/coreui-vue/src/components/navbar/CNavbarToggler.ts
@@ -9,7 +9,7 @@ const CNavbarToggler = defineComponent({
         {
           class: 'navbar-toggler',
         },
-        slots.default ? slots.default() : h('span', { class: ['navbar-toggler-icon'] }),
+        slots.default ? slots.default() : h('span', { class: ['navbar-toggler-icon'] })
       )
   },
 })

--- a/packages/coreui-vue/src/components/pagination/CPagination.ts
+++ b/packages/coreui-vue/src/components/pagination/CPagination.ts
@@ -42,8 +42,8 @@ const CPagination = defineComponent({
               },
             ],
           },
-          slots.default && slots.default(),
-        ),
+          slots.default && slots.default()
+        )
       )
   },
 })

--- a/packages/coreui-vue/src/components/pagination/CPaginationItem.ts
+++ b/packages/coreui-vue/src/components/pagination/CPaginationItem.ts
@@ -47,9 +47,9 @@ const CPaginationItem = defineComponent({
               },
               {
                 default: () => slots.default && slots.default(),
-              },
+              }
             )
-          : h(component, { class: ['page-link'] }, slots.default && slots.default()),
+          : h(component, { class: ['page-link'] }, slots.default && slots.default())
       )
     }
   },

--- a/packages/coreui-vue/src/components/placeholder/CPlaceholder.ts
+++ b/packages/coreui-vue/src/components/placeholder/CPlaceholder.ts
@@ -104,7 +104,7 @@ export const CPlaceholder = defineComponent({
             repsonsiveClassNames,
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/popover/CPopover.ts
+++ b/packages/coreui-vue/src/components/popover/CPopover.ts
@@ -220,7 +220,7 @@ const CPopover = defineComponent({
                         { class: 'popover-header' },
                         {
                           default: () => (slots.title && slots.title()) || props.title,
-                        },
+                        }
                       ),
                     (props.content || slots.content) &&
                       h(
@@ -228,12 +228,12 @@ const CPopover = defineComponent({
                         { class: 'popover-body' },
                         {
                           default: () => (slots.content && slots.content()) || props.content,
-                        },
+                        }
                       ),
-                  ],
-                ),
+                  ]
+                )
             ),
-        },
+        }
       ),
       slots.toggler &&
         slots.toggler({

--- a/packages/coreui-vue/src/components/progress/CProgress.ts
+++ b/packages/coreui-vue/src/components/progress/CProgress.ts
@@ -101,8 +101,8 @@ const CProgress = defineComponent({
                 value: props.value,
                 variant: props.variant,
               },
-              () => slots.default && slots.default(),
-            ),
+              () => slots.default && slots.default()
+            )
       )
   },
 })

--- a/packages/coreui-vue/src/components/progress/CProgressBar.ts
+++ b/packages/coreui-vue/src/components/progress/CProgressBar.ts
@@ -51,7 +51,7 @@ const CProgressBar = defineComponent({
           ],
           ...(!stacked && { style: { width: `${props.value}%` } }),
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/progress/CProgressStacked.ts
+++ b/packages/coreui-vue/src/components/progress/CProgressStacked.ts
@@ -11,7 +11,7 @@ const CProgressStacked = defineComponent({
         {
           class: 'progress-stacked',
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/search-button/CSearchButton.ts
+++ b/packages/coreui-vue/src/components/search-button/CSearchButton.ts
@@ -53,16 +53,11 @@ export const CSearchButton = defineComponent({
     const shortcuts = computed(() => parseShortcut(props.shortcut))
     const preferredShortcut = computed(() => getPreferredShortcut(shortcuts.value))
     const shortcutTokens = computed(() =>
-      formatShortcutTokens(preferredShortcut.value?.shortcut || ''),
+      formatShortcutTokens(preferredShortcut.value?.shortcut || '')
     )
 
     const handleShortcut = (event: KeyboardEvent) => {
-      if (
-        props.disabled ||
-        event.defaultPrevented ||
-        event.repeat ||
-        shouldIgnoreShortcut(event)
-      ) {
+      if (props.disabled || event.defaultPrevented || event.repeat || shouldIgnoreShortcut(event)) {
         return
       }
 
@@ -143,7 +138,7 @@ export const CSearchButton = defineComponent({
                       h('path', {
                         fill: 'currentColor',
                         d: 'm479.6 399.716-81.084-81.084-62.368-25.767A175 175 0 0 0 368 192c0-97.047-78.953-176-176-176S16 94.953 16 192s78.953 176 176 176a175.03 175.03 0 0 0 101.619-32.377l25.7 62.2 81.081 81.088a56 56 0 1 0 79.2-79.195M48 192c0-79.4 64.6-144 144-144s144 64.6 144 144-64.6 144-144 144S48 271.4 48 192m408.971 264.284a24.03 24.03 0 0 1-33.942 0l-76.572-76.572-23.894-57.835 57.837 23.894 76.573 76.572a24.03 24.03 0 0 1-.002 33.941',
-                      }),
+                      })
                     ),
                 h('span', { class: 'search-button-placeholder' }, props.placeholder),
               ],
@@ -158,11 +153,11 @@ export const CSearchButton = defineComponent({
                   'data-coreui-search-button-key': key,
                   key,
                 },
-                key,
-              ),
-            ),
+                key
+              )
+            )
           ),
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/sidebar/CSidebar.ts
+++ b/packages/coreui-vue/src/components/sidebar/CSidebar.ts
@@ -96,7 +96,7 @@ const CSidebar = defineComponent({
     const mobile = ref()
     const visibleMobile = ref(false)
     const visibleDesktop = ref(
-      props.visible === undefined ? (props.overlaid ? false : true) : props.visible,
+      props.visible === undefined ? (props.overlaid ? false : true) : props.visible
     )
 
     watch(inViewport, () => {
@@ -106,7 +106,7 @@ const CSidebar = defineComponent({
 
     watch(
       () => props.visible,
-      () => props.visible !== undefined && handleVisibleChange(props.visible),
+      () => props.visible !== undefined && handleVisibleChange(props.visible)
     )
 
     watch(mobile, () => {
@@ -203,7 +203,7 @@ const CSidebar = defineComponent({
           ],
           ref: sidebarRef,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       ),
       mobile.value &&
         h(CBackdrop, {

--- a/packages/coreui-vue/src/components/sidebar/CSidebarBrand.ts
+++ b/packages/coreui-vue/src/components/sidebar/CSidebarBrand.ts
@@ -21,7 +21,7 @@ const CSidebarBrand = defineComponent({
       h(
         props.as ?? (props.href ? 'a' : 'div'),
         { class: 'sidebar-brand', href: props.href },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/sidebar/CSidebarNav.ts
+++ b/packages/coreui-vue/src/components/sidebar/CSidebarNav.ts
@@ -47,7 +47,7 @@ const CSidebarNav = defineComponent({
         },
         {
           default: () => slots.default && slots.default(),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/spinner/CSpinner.ts
+++ b/packages/coreui-vue/src/components/spinner/CSpinner.ts
@@ -3,13 +3,13 @@ import { defineComponent, h } from 'vue'
 const CSpinner = defineComponent({
   name: 'CSpinner',
   props: {
-        /**
+    /**
      * Component used for the root node. Either a string to use a HTML element or a component.
      */
-        as: {
-          type: String,
-          default: 'div',
-        },
+    as: {
+      type: String,
+      default: 'div',
+    },
     /**
      * Sets the color context of the component to one of CoreUI’s themed colors.
      *
@@ -75,7 +75,7 @@ const CSpinner = defineComponent({
           ],
           role: 'status',
         },
-        h('span', { class: ['visually-hidden'] }, props.visuallyHiddenLabel),
+        h('span', { class: ['visually-hidden'] }, props.visuallyHiddenLabel)
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTable.ts
+++ b/packages/coreui-vue/src/components/table/CTable.ts
@@ -186,7 +186,7 @@ const CTable = defineComponent({
                 {},
                 {
                   default: () => props.caption || props.captionTop,
-                },
+                }
               ),
             props.columns &&
               h(
@@ -213,13 +213,13 @@ const CTable = defineComponent({
                                 },
                                 {
                                   default: () => getColumnLabel(column),
-                                },
-                              ),
+                                }
+                              )
                             ),
                         ],
-                      },
+                      }
                     ),
-                },
+                }
               ),
             props.items &&
               h(
@@ -252,15 +252,15 @@ const CTable = defineComponent({
                                       },
                                       {
                                         default: () => item[colName],
-                                      },
-                                    ),
+                                      }
+                                    )
                                 ),
                             ],
-                          },
-                        ),
+                          }
+                        )
                       ),
                   ],
-                },
+                }
               ),
             slots.default && slots.default(),
             props.footer &&
@@ -286,16 +286,16 @@ const CTable = defineComponent({
                                 },
                                 {
                                   default: () => (typeof item === 'object' ? item.label : item),
-                                },
-                              ),
+                                }
+                              )
                             ),
                         ],
-                      },
+                      }
                     ),
-                },
+                }
               ),
           ],
-        },
+        }
       )
     return () => [
       props.responsive
@@ -307,7 +307,7 @@ const CTable = defineComponent({
                   ? 'table-responsive'
                   : `table-responsive-${props.responsive}`,
             },
-            table(),
+            table()
           )
         : table(),
     ]

--- a/packages/coreui-vue/src/components/table/CTableBody.ts
+++ b/packages/coreui-vue/src/components/table/CTableBody.ts
@@ -23,7 +23,7 @@ const CTableBody = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTableDataCell.ts
+++ b/packages/coreui-vue/src/components/table/CTableDataCell.ts
@@ -45,7 +45,7 @@ const CTableDataCell = defineComponent({
           ],
           ...(props.scope && { scope: props.scope }),
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTableFoot.ts
+++ b/packages/coreui-vue/src/components/table/CTableFoot.ts
@@ -23,7 +23,7 @@ const CTableFoot = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTableHead.ts
+++ b/packages/coreui-vue/src/components/table/CTableHead.ts
@@ -23,7 +23,7 @@ const CTableHead = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTableHeaderCell.ts
+++ b/packages/coreui-vue/src/components/table/CTableHeaderCell.ts
@@ -23,7 +23,7 @@ const CTableHeaderCell = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/CTableRow.ts
+++ b/packages/coreui-vue/src/components/table/CTableRow.ts
@@ -40,7 +40,7 @@ const CTableRow = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/table/utils.ts
+++ b/packages/coreui-vue/src/components/table/utils.ts
@@ -2,16 +2,16 @@ import type { Column, Item } from './types'
 
 export const pretifyName = (name: string) => {
   return name
-    .replace(/[-_.]/g, ' ')
-    .replace(/ +/g, ' ')
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replaceAll(/[-_.]/g, ' ')
+    .replaceAll(/ +/g, ' ')
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2')
     .split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 }
 
 export const getColumnLabel = (column: Column | string) =>
-  typeof column === 'object' ? column.label ?? pretifyName(column.key) : pretifyName(column)
+  typeof column === 'object' ? (column.label ?? pretifyName(column.key)) : pretifyName(column)
 
 export const getColumnNames = (columns: (string | Column)[] | undefined, items?: Item[]) =>
   columns

--- a/packages/coreui-vue/src/components/tabs/CTab.ts
+++ b/packages/coreui-vue/src/components/tabs/CTab.ts
@@ -44,7 +44,7 @@ const CTab = defineComponent({
           onClick: () => setActiveItemKey(props.itemKey),
           onFocus: () => setActiveItemKey(props.itemKey),
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/tabs/CTabList.ts
+++ b/packages/coreui-vue/src/components/tabs/CTabList.ts
@@ -23,7 +23,14 @@ const CTabList = defineComponent({
     variant: {
       type: String,
       validator: (value: string) => {
-        return ['enclosed', 'enclosed-pills', 'pills', 'tabs', 'underline', 'underline-border'].includes(value)
+        return [
+          'enclosed',
+          'enclosed-pills',
+          'pills',
+          'tabs',
+          'underline',
+          'underline-border',
+        ].includes(value)
       },
     },
   },
@@ -42,9 +49,9 @@ const CTabList = defineComponent({
       ) {
         event.preventDefault()
         const target = event.target as HTMLElement
-        // eslint-disable-next-line unicorn/prefer-spread
+
         const items: HTMLElement[] = Array.from(
-          tabListRef.value.querySelectorAll('.nav-link:not(.disabled):not(:disabled)'),
+          tabListRef.value.querySelectorAll('.nav-link:not(.disabled):not(:disabled)')
         )
 
         let nextActiveElement
@@ -56,7 +63,7 @@ const CTabList = defineComponent({
             items,
             target,
             event.key === 'ArrowDown' || event.key === 'ArrowRight',
-            true,
+            true
           )
         }
 
@@ -82,7 +89,7 @@ const CTabList = defineComponent({
           onKeydown: (event) => handleKeydown(event),
           ref: tabListRef,
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/tabs/CTabPane.ts
+++ b/packages/coreui-vue/src/components/tabs/CTabPane.ts
@@ -74,10 +74,10 @@ const CTabPane = defineComponent({
                 ],
                 ref: tabPaneRef,
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
-            [[vShow, props.visible]],
-          ),
+            [[vShow, props.visible]]
+          )
       )
   },
 })

--- a/packages/coreui-vue/src/components/tabs/CTabPanel.ts
+++ b/packages/coreui-vue/src/components/tabs/CTabPanel.ts
@@ -62,7 +62,7 @@ const CTabPanel = defineComponent({
       },
       {
         immediate: true,
-      },
+      }
     )
 
     watch(
@@ -72,7 +72,7 @@ const CTabPanel = defineComponent({
       },
       {
         immediate: true,
-      },
+      }
     )
 
     const handleEnter = (el: RendererElement, done: () => void) => {
@@ -117,10 +117,10 @@ const CTabPanel = defineComponent({
                 tabindex: 0,
                 ref: tabPaneRef,
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
-            [[vShow, visible.value]],
-          ),
+            [[vShow, visible.value]]
+          )
       )
   },
 })

--- a/packages/coreui-vue/src/components/tabs/CTabs.ts
+++ b/packages/coreui-vue/src/components/tabs/CTabs.ts
@@ -9,7 +9,7 @@ const CTabs = defineComponent({
     activeItemKey: {
       type: [Number, String],
       required: true,
-    }
+    },
   },
   emits: [
     /**
@@ -29,7 +29,7 @@ const CTabs = defineComponent({
       (value) => {
         activeItemKey.value = value
         emit('change', value)
-      },
+      }
     )
 
     provide('activeItemKey', activeItemKey)

--- a/packages/coreui-vue/src/components/toast/CToast.ts
+++ b/packages/coreui-vue/src/components/toast/CToast.ts
@@ -114,9 +114,9 @@ const CToast = defineComponent({
                 'aria-atomic': true,
                 role: 'alert',
               },
-              slots.default && slots.default(),
+              slots.default && slots.default()
             ),
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/toast/CToastClose.ts
+++ b/packages/coreui-vue/src/components/toast/CToastClose.ts
@@ -23,7 +23,6 @@ const CToastClose = defineComponent({
     'close',
   ],
   setup(props: CCloseButtonProps, { slots, emit }) {
-    // eslint-disable-next-line no-unused-vars
     const updateVisible = inject('updateVisible') as (visible: boolean) => void
     const handleClose = () => {
       emit('close')
@@ -38,7 +37,7 @@ const CToastClose = defineComponent({
                 handleClose()
               },
             },
-            () => slots.default && slots.default(),
+            () => slots.default && slots.default()
           )
         : h(CCloseButton, {
             ...props,

--- a/packages/coreui-vue/src/components/toast/CToaster.ts
+++ b/packages/coreui-vue/src/components/toast/CToaster.ts
@@ -43,7 +43,7 @@ const CToaster = defineComponent({
             },
           ],
         },
-        slots.default && slots.default(),
+        slots.default && slots.default()
       )
   },
 })

--- a/packages/coreui-vue/src/components/tooltip/CTooltip.ts
+++ b/packages/coreui-vue/src/components/tooltip/CTooltip.ts
@@ -216,12 +216,12 @@ const CTooltip = defineComponent({
                         { class: 'tooltip-inner' },
                         {
                           default: () => (slots.content && slots.content()) || props.content,
-                        },
+                        }
                       ),
-                  ],
-                ),
+                  ]
+                )
             ),
-        },
+        }
       ),
       slots.toggler &&
         slots.toggler({

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsA.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsA.ts
@@ -49,7 +49,7 @@ const CWidgetStatsA = defineComponent({
                     { class: 'fs-4 fw-semibold' },
                     {
                       default: () => (slots.value && slots.value()) || props.value,
-                    },
+                    }
                   ),
                 (props.title || slots.title) &&
                   h(
@@ -57,21 +57,21 @@ const CWidgetStatsA = defineComponent({
                     {},
                     {
                       default: () => (slots.title && slots.title()) || props.title,
-                    },
+                    }
                   ),
               ]),
               /**
                * @slot Location for action component, ex. `<CDropdown>`.
                */
               slots.action && slots.action(),
-            ],
+            ]
           ),
           /**
            * @slot Location for chart component.
            */
           slots.chart && slots.chart(),
           slots.default && slots.default(),
-        ],
+        ]
       )
   },
 })

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsB.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsB.ts
@@ -77,7 +77,7 @@ const CWidgetStatsB = defineComponent({
                   },
                   {
                     default: () => (slots.value && slots.value()) || props.value,
-                  },
+                  }
                 ),
               (props.title || slots.title) &&
                 h(
@@ -85,7 +85,7 @@ const CWidgetStatsB = defineComponent({
                   {},
                   {
                     default: () => (slots.title && slots.title()) || props.title,
-                  },
+                  }
                 ),
               h(CProgress, {
                 class: 'my-2',
@@ -102,10 +102,10 @@ const CWidgetStatsB = defineComponent({
                   },
                   {
                     default: () => (slots.text && slots.text()) || props.text,
-                  },
+                  }
                 ),
-            ],
-          ),
+            ]
+          )
       )
   },
 })

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsC.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsC.ts
@@ -78,7 +78,7 @@ const CWidgetStatsC = defineComponent({
                       props.inverse ? 'text-white text-opacity-75' : 'text-body-secondary',
                     ],
                   },
-                  slots.icon && slots.icon(),
+                  slots.icon && slots.icon()
                 ),
               (props.value || slots.value) &&
                 h(
@@ -88,7 +88,7 @@ const CWidgetStatsC = defineComponent({
                   },
                   {
                     default: () => (slots.value && slots.value()) || props.value,
-                  },
+                  }
                 ),
               (props.title || slots.title) &&
                 h(
@@ -101,7 +101,7 @@ const CWidgetStatsC = defineComponent({
                   },
                   {
                     default: () => (slots.title && slots.title()) || props.title,
-                  },
+                  }
                 ),
               h(CProgress, {
                 class: 'my-2',
@@ -110,8 +110,8 @@ const CWidgetStatsC = defineComponent({
                 ...(props.progress && props.progress.value && { value: props.progress.value }),
                 white: props.inverse,
               }),
-            ],
-          ),
+            ]
+          )
       )
   },
 })

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsD.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsD.ts
@@ -54,7 +54,7 @@ const CWidgetStatsD = defineComponent({
                   },
                 ],
               },
-              () => [slots.icon && slots.icon(), slots.chart && slots.chart()],
+              () => [slots.icon && slots.icon(), slots.chart && slots.chart()]
             ),
             h(
               CCardBody,
@@ -75,16 +75,16 @@ const CWidgetStatsD = defineComponent({
                           h(
                             CCol,
                             { class: 'text-uppercase text-body-secondary small' },
-                            () => value.title,
+                            () => value.title
                           ),
                         ],
-                      },
+                      }
                     ),
                   ]),
-              },
+              }
             ),
           ],
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsE.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsE.ts
@@ -39,7 +39,7 @@ const CWidgetStatsE = defineComponent({
                 },
                 {
                   default: () => (slots.title && slots.title()) || props.title,
-                },
+                }
               ),
             (props.value || slots.value) &&
               h(
@@ -49,12 +49,12 @@ const CWidgetStatsE = defineComponent({
                 },
                 {
                   default: () => (slots.value && slots.value()) || props.value,
-                },
+                }
               ),
             slots.chart && slots.chart(),
             slots.default && slots.default(),
-          ],
-        ),
+          ]
+        )
       )
   },
 })

--- a/packages/coreui-vue/src/components/widgets/CWidgetStatsF.ts
+++ b/packages/coreui-vue/src/components/widgets/CWidgetStatsF.ts
@@ -64,7 +64,7 @@ const CWidgetStatsF = defineComponent({
                       props.padding ? 'p-3' : 'p-4',
                     ],
                   },
-                  (slots.default && slots.default()) || (slots.icon && slots.icon()),
+                  (slots.default && slots.default()) || (slots.icon && slots.icon())
                 ),
                 h('div', {}, [
                   (props.value || slots.value) &&
@@ -75,7 +75,7 @@ const CWidgetStatsF = defineComponent({
                       },
                       {
                         default: () => (slots.value && slots.value()) || props.value,
-                      },
+                      }
                     ),
                   (props.title || slots.title) &&
                     h(
@@ -85,14 +85,14 @@ const CWidgetStatsF = defineComponent({
                       },
                       {
                         default: () => (slots.title && slots.title()) || props.title,
-                      },
+                      }
                     ),
                 ]),
-              ],
+              ]
             ),
             slots.footer && h(CCardFooter, {}, () => slots.footer && slots.footer()),
           ],
-        },
+        }
       )
   },
 })

--- a/packages/coreui-vue/src/directives/v-c-popover.ts
+++ b/packages/coreui-vue/src/directives/v-c-popover.ts
@@ -19,7 +19,7 @@ const addPopoverElement = (
   el: HTMLElement,
   popover: HTMLDivElement,
   popperOptions: Partial<Options>,
-  uID: string,
+  uID: string
 ) => {
   el.setAttribute('aria-describedby', uID)
   document.body.appendChild(popover)
@@ -41,7 +41,7 @@ const togglePopoverElement = (
   el: HTMLElement,
   popover: HTMLDivElement,
   popperOptions: Partial<Options>,
-  uID: string,
+  uID: string
 ) => {
   const popperElement = document.getElementById(popover.id)
   if (popperElement && popperElement.classList.contains('show')) {
@@ -57,7 +57,7 @@ export default {
   mounted(el: HTMLElement, binding: DirectiveBinding): void {
     const { getUID } = useUniqueId('popover')
     const value = binding.value
-    const content = typeof value === 'string' ? value : value.content ?? ''
+    const content = typeof value === 'string' ? value : (value.content ?? '')
     const header = value.header ?? ''
     const trigger = value.trigger ?? 'click'
 

--- a/packages/coreui-vue/src/directives/v-c-tooltip.ts
+++ b/packages/coreui-vue/src/directives/v-c-tooltip.ts
@@ -18,7 +18,7 @@ const addTooltipElement = (
   el: HTMLElement,
   tooltip: HTMLDivElement,
   popperOptions: Partial<Options>,
-  uID: string,
+  uID: string
 ) => {
   el.setAttribute('aria-describedby', uID)
   document.body.appendChild(tooltip)
@@ -40,7 +40,7 @@ const toggleTooltipElement = (
   el: HTMLElement,
   tooltip: HTMLDivElement,
   popperOptions: Partial<Options>,
-  uID: string,
+  uID: string
 ) => {
   const popperElement = document.getElementById(tooltip.id)
   if (popperElement && popperElement.classList.contains('show')) {
@@ -55,7 +55,7 @@ export default {
   mounted(el: HTMLElement, binding: DirectiveBinding): void {
     const { getUID } = useUniqueId('tooltip')
     const value = binding.value
-    const content = typeof value === 'string' ? value : value.content ?? ''
+    const content = typeof value === 'string' ? value : (value.content ?? '')
     const trigger = value.trigger ?? 'hover'
 
     // Popper Config

--- a/packages/coreui-vue/src/index.ts
+++ b/packages/coreui-vue/src/index.ts
@@ -12,7 +12,7 @@ const CoreuiVue = {
     for (const key in Directives) {
       app.directive(
         (Directives as { [key: string]: any })[key]['name'],
-        (Directives as { [key: string]: any })[key],
+        (Directives as { [key: string]: any })[key]
       )
     }
   },

--- a/packages/coreui-vue/src/utils/getNextActiveElement.ts
+++ b/packages/coreui-vue/src/utils/getNextActiveElement.ts
@@ -2,7 +2,7 @@ const getNextActiveElement = (
   list: HTMLElement[],
   activeElement: HTMLElement,
   shouldGetNext: boolean,
-  isCycleAllowed: boolean,
+  isCycleAllowed: boolean
 ) => {
   const listLength = list.length
   let index = list.indexOf(activeElement)

--- a/packages/coreui-vue/src/utils/transition.ts
+++ b/packages/coreui-vue/src/utils/transition.ts
@@ -7,7 +7,7 @@ const execute = (callback: () => void) => {
 export const executeAfterTransition = (
   callback: () => void,
   transitionElement: HTMLElement,
-  waitForTransition = true,
+  waitForTransition = true
 ) => {
   if (!waitForTransition) {
     execute(callback)


### PR DESCRIPTION
## What

Local `yarn lint` in `coreui-vue` couldn't even load — `vue-eslint-parser` is a peer dependency of `eslint-plugin-vue@10` and is no longer auto-installed by yarn classic. This adds it as an explicit dev dependency so lint runs, then applies the safe autofixes it surfaced.

## Changes

- **Add `vue-eslint-parser` dev dep** so `yarn lint` runs locally.
- **Apply safe autofixes** (prettier formatting, es5 trailing commas): **330 → 31** errors.
- **Disable 4 `unicorn` autofix rules whose fixes break TS typing in this codebase** (each caught by the jest suite, not guessed):
  - `prefer-at` — `.at(i)` returns `T | undefined` where `arr[i]` returns `T`
  - `prefer-spread` — `Array.from(NodeList)` → `[...]` narrows `HTMLElement[]` to `Element[]`
  - `no-useless-undefined` — `() => undefined` → `() => {}` flips the return to `void`
  - `prefer-global-this` — `window` → `globalThis` rewrite known to break code

## Verification

- Full jest suite: **123/123 suites, 628 tests green**
- `yarn lib:build` passes
- No `dist/` in the diff

## Follow-ups (not in this PR)

- 31 remaining lint errors need manual rewrites / typing (`no-unused-expressions`, `no-explicit-any`, `consistent-function-scoping`, `no-negation-in-equality-check`).
- The `project-check`/`daily-project-check` workflows are dead (trigger on `master`, node 12.x, call a nonexistent `jest:test`) — neither lint nor tests are gated on PRs. They should be revived (branch `main`, node ≥18, `yarn lint` + `yarn test`).