### PR TITLE
chore(eslint): resolve remaining lint errors

### DIFF
--- a/packages/coreui-vue/src/components/carousel/CCarousel.ts
+++ b/packages/coreui-vue/src/components/carousel/CCarousel.ts
@@ -110,9 +110,9 @@ const CCarousel = defineComponent({
       }
       direction.value = _direction
       if (_direction === 'next') {
-        active.value === items.value.length - 1 ? (active.value = 0) : active.value++
+        active.value = active.value === items.value.length - 1 ? 0 : active.value + 1
       } else {
-        active.value === 0 ? (active.value = items.value.length - 1) : active.value--
+        active.value = active.value === 0 ? items.value.length - 1 : active.value - 1
       }
     }
 
@@ -167,18 +167,22 @@ const CCarousel = defineComponent({
     onUpdated(() => {
       watch(animating, () => {
         if (props.wrap) {
-          !animating.value && cycle()
+          if (!animating.value) {
+            cycle()
+          }
           return
         }
 
-        if (!props.wrap && active.value < items.value.length - 1) {
-          !animating.value && cycle()
+        if (!props.wrap && active.value < items.value.length - 1 && !animating.value) {
+          cycle()
         }
       })
     })
 
     watch(visible, () => {
-      visible.value && cycle()
+      if (visible.value) {
+        cycle()
+      }
     })
 
     return () =>

--- a/packages/coreui-vue/src/components/carousel/CCarouselItem.ts
+++ b/packages/coreui-vue/src/components/carousel/CCarouselItem.ts
@@ -37,7 +37,9 @@ const CCarouselItem = defineComponent({
     const setCustomInterval = inject('setCustomInterval') as (value: boolean | number) => void
 
     watch(active, (active, prevActive) => {
-      active && setCustomInterval(props.interval)
+      if (active) {
+        setCustomInterval(props.interval)
+      }
       if (!prevActive && active) {
         orderClassName.value = `carousel-item-${props.direction}`
         setCustomInterval(props.interval)

--- a/packages/coreui-vue/src/components/chip-input/__tests__/CChipInput.spec.ts
+++ b/packages/coreui-vue/src/components/chip-input/__tests__/CChipInput.spec.ts
@@ -339,10 +339,9 @@ describe('CChipInput', () => {
   })
 
   it('applies chipClassName as function', async () => {
-    const classNameFn = (value: string) => `chip-${value}`
     const wrapper = mount(CChipInput, {
       props: {
-        chipClassName: classNameFn,
+        chipClassName: (value: string) => `chip-${value}`,
         modelValue: ['primary', 'secondary'],
       },
     })

--- a/packages/coreui-vue/src/components/collapse/CCollapse.ts
+++ b/packages/coreui-vue/src/components/collapse/CCollapse.ts
@@ -49,7 +49,7 @@ const CCollapse = defineComponent({
     const handleAfterEnter = (el: RendererElement) => {
       show.value = true
       collapsing.value = false
-      props.horizontal ? el.style.removeProperty('width') : el.style.removeProperty('height')
+      el.style.removeProperty(props.horizontal ? 'width' : 'height')
     }
 
     const handleBeforeLeave = (el: RendererElement) => {
@@ -76,7 +76,7 @@ const CCollapse = defineComponent({
 
     const handleAfterLeave = (el: RendererElement) => {
       collapsing.value = false
-      props.horizontal ? el.style.removeProperty('width') : el.style.removeProperty('height')
+      el.style.removeProperty(props.horizontal ? 'width' : 'height')
     }
 
     return () =>

--- a/packages/coreui-vue/src/components/dropdown/CDropdown.ts
+++ b/packages/coreui-vue/src/components/dropdown/CDropdown.ts
@@ -249,16 +249,14 @@ const CDropdown = defineComponent({
 
       window.removeEventListener('click', handleClick)
       window.removeEventListener('keyup', handleKeyup)
-      dropdownMenuRef.value && dropdownMenuRef.value.removeEventListener('keydown', handleKeydown)
-      dropdownToggleRef.value &&
-        dropdownToggleRef.value.removeEventListener('keydown', handleKeydown)
+      dropdownMenuRef.value?.removeEventListener('keydown', handleKeydown)
+      dropdownToggleRef.value?.removeEventListener('keydown', handleKeydown)
       emit('hide')
     })
 
     onUnmounted(() => {
-      dropdownToggleRef.value &&
-        dropdownToggleRef.value.removeEventListener('keydown', handleKeydown)
-      dropdownMenuRef.value && dropdownMenuRef.value.removeEventListener('keydown', handleKeydown)
+      dropdownToggleRef.value?.removeEventListener('keydown', handleKeydown)
+      dropdownMenuRef.value?.removeEventListener('keydown', handleKeydown)
     })
 
     provide('config', {

--- a/packages/coreui-vue/src/components/focus-trap/CFocusTrap.ts
+++ b/packages/coreui-vue/src/components/focus-trap/CFocusTrap.ts
@@ -283,7 +283,7 @@ const CFocusTrap = defineComponent({
       const vnode = vnodes?.[0]
       if (!vnode) return null
 
-      const originalRef = (vnode.props as any)?.ref
+      const originalRef = (vnode.props as Record<string, unknown> | null)?.ref
 
       return cloneVNode(vnode, {
         ref: (el) => {
@@ -295,7 +295,7 @@ const CFocusTrap = defineComponent({
           if (typeof originalRef === 'function') {
             originalRef(el)
           } else if (originalRef && typeof originalRef === 'object' && 'value' in originalRef) {
-            ;(originalRef as { value: any }).value = el
+            ;(originalRef as { value: unknown }).value = el
           }
         },
       })

--- a/packages/coreui-vue/src/components/grid/CContainer.ts
+++ b/packages/coreui-vue/src/components/grid/CContainer.ts
@@ -43,7 +43,9 @@ const CContainer = defineComponent({
     BREAKPOINTS.forEach((bp) => {
       const breakpoint = props[bp]
 
-      breakpoint && repsonsiveClassNames.push(`container-${bp}`)
+      if (breakpoint) {
+        repsonsiveClassNames.push(`container-${bp}`)
+      }
     })
     return () =>
       h(

--- a/packages/coreui-vue/src/components/modal/CModal.ts
+++ b/packages/coreui-vue/src/components/modal/CModal.ts
@@ -181,7 +181,9 @@ const CModal = defineComponent({
     }
 
     const handleAfterEnter = () => {
-      props.focus && modalRef.value?.focus()
+      if (props.focus) {
+        modalRef.value?.focus()
+      }
       window.addEventListener('mousedown', handleMouseDown)
       window.addEventListener('keydown', handleKeyDown)
     }

--- a/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
+++ b/packages/coreui-vue/src/components/nav/__tests__/CNavGroup.spec.ts
@@ -90,32 +90,32 @@ describe(`${ComponentName} uncontrolled mode`, () => {
   })
 })
 
-describe(`${ComponentName} nested groups`, () => {
-  const nested = () =>
-    mount(CSidebarNav, {
-      slots: {
-        default: () => [
-          h(
-            CNavGroup,
-            {},
-            {
-              togglerContent: () => 'A',
-              default: () => [
-                h(
-                  CNavGroup,
-                  {},
-                  {
-                    togglerContent: () => 'B',
-                    default: () => [h(CNavItem, { href: '#' }, () => 'item')],
-                  }
-                ),
-              ],
-            }
-          ),
-        ],
-      },
-    })
+const nested = () =>
+  mount(CSidebarNav, {
+    slots: {
+      default: () => [
+        h(
+          CNavGroup,
+          {},
+          {
+            togglerContent: () => 'A',
+            default: () => [
+              h(
+                CNavGroup,
+                {},
+                {
+                  togglerContent: () => 'B',
+                  default: () => [h(CNavItem, { href: '#' }, () => 'item')],
+                }
+              ),
+            ],
+          }
+        ),
+      ],
+    },
+  })
 
+describe(`${ComponentName} nested groups`, () => {
   it('renders and toggles per level', async () => {
     const wrapper = nested()
     const group = (index: number) => wrapper.findAll('.nav-group')[index]

--- a/packages/coreui-vue/src/components/sidebar/CSidebar.ts
+++ b/packages/coreui-vue/src/components/sidebar/CSidebar.ts
@@ -101,7 +101,7 @@ const CSidebar = defineComponent({
 
     watch(inViewport, () => {
       emit('visible-change', inViewport.value)
-      inViewport.value ? emit('show') : emit('hide')
+      emit(inViewport.value ? 'show' : 'hide')
     })
 
     watch(
@@ -174,11 +174,14 @@ const CSidebar = defineComponent({
 
     const handleOnClick = (event: Event) => {
       const target = event.target as HTMLAnchorElement
-      target &&
+      if (
+        target &&
         target.classList.contains('nav-link') &&
         !target.classList.contains('nav-group-toggle') &&
-        mobile.value &&
+        mobile.value
+      ) {
         handleHide()
+      }
     }
 
     return () => [

--- a/packages/coreui-vue/src/components/table/types.ts
+++ b/packages/coreui-vue/src/components/table/types.ts
@@ -14,6 +14,7 @@ export type FooterItem = {
 }
 
 export type Item = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: number | string | any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _props?: any

--- a/packages/coreui-vue/src/components/toast/CToast.ts
+++ b/packages/coreui-vue/src/components/toast/CToast.ts
@@ -92,10 +92,18 @@ const CToast = defineComponent({
           leaveToClass: 'show',
           onAfterEnter: (el) => {
             el.classList.add('show')
-            props.index ? emit('show', props.index) : emit('show')
+            if (props.index) {
+              emit('show', props.index)
+            } else {
+              emit('show')
+            }
           },
           onAfterLeave: () => {
-            props.index ? emit('close', props.index) : emit('close')
+            if (props.index) {
+              emit('close', props.index)
+            } else {
+              emit('close')
+            }
           },
         },
         {

--- a/packages/coreui-vue/src/directives/v-c-popover.ts
+++ b/packages/coreui-vue/src/directives/v-c-popover.ts
@@ -81,10 +81,11 @@ export default {
     binding.arg = uID
     const popover = createPopoverElement(uID, header, content)
 
-    trigger.includes('click') &&
+    if (trigger.includes('click')) {
       el.addEventListener('click', () => {
         togglePopoverElement(el, popover, popperOptions, uID)
       })
+    }
 
     if (trigger.includes('focus')) {
       el.addEventListener('focus', () => {
@@ -106,6 +107,8 @@ export default {
   },
   unmounted(_el: HTMLElement, binding: DirectiveBinding): void {
     const popover = binding.arg && document.getElementById(binding.arg)
-    popover && popover.remove()
+    if (popover) {
+      popover.remove()
+    }
   },
 }

--- a/packages/coreui-vue/src/directives/v-c-tooltip.ts
+++ b/packages/coreui-vue/src/directives/v-c-tooltip.ts
@@ -78,10 +78,11 @@ export default {
     binding.arg = uID
     const tooltip = createTooltipElement(uID, content)
 
-    trigger.includes('click') &&
+    if (trigger.includes('click')) {
       el.addEventListener('click', () => {
         toggleTooltipElement(el, tooltip, popperOptions, uID)
       })
+    }
 
     if (trigger.includes('focus')) {
       el.addEventListener('focus', () => {
@@ -103,6 +104,8 @@ export default {
   },
   beforeUnmount(_el: HTMLElement, binding: DirectiveBinding): void {
     const tooltip = binding.arg && document.getElementById(binding.arg)
-    tooltip && tooltip.remove()
+    if (tooltip) {
+      tooltip.remove()
+    }
   },
 }

--- a/packages/coreui-vue/src/directives/v-c-visible.ts
+++ b/packages/coreui-vue/src/directives/v-c-visible.ts
@@ -18,7 +18,7 @@ export const vVisible: ObjectDirective<VShowElement> = {
     }
   },
   updated(el, { value, oldValue }, { transition }) {
-    if (!value === !oldValue) return
+    if (Boolean(value) === Boolean(oldValue)) return
     if (transition) {
       if (value) {
         transition.beforeEnter(el)

--- a/packages/coreui-vue/src/utils/ComponentProps.ts
+++ b/packages/coreui-vue/src/utils/ComponentProps.ts
@@ -1,6 +1,7 @@
 import { DefineComponent, ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
 
 export type ComponentProps<T> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends DefineComponent<ExtractPropTypes<infer Props>, any, any>
     ? ExtractPublicPropTypes<Props>
     : never

--- a/packages/coreui-vue/src/utils/transition.ts
+++ b/packages/coreui-vue/src/utils/transition.ts
@@ -19,7 +19,7 @@ export const executeAfterTransition = (
 
   let called = false
 
-  const handler = ({ target }: { target: any }) => {
+  const handler = ({ target }: Event) => {
     if (target !== transitionElement) {
       return
     }


### PR DESCRIPTION
Clears the 31 remaining ESLint errors that auto-fix couldn't touch, so `yarn lint` is green and can gate PRs.

## Changes

- **`@typescript-eslint/no-unused-expressions` (22)** — statement-position ternaries and `cond && fn()` short-circuits rewritten as `if` / `if-else`, or folded into the expression they guard (e.g. `emit(cond ? 'show' : 'hide')`, `el.style.removeProperty(cond ? 'width' : 'height')`, optional chaining for `removeEventListener`).
- **`@typescript-eslint/no-explicit-any` (6)** — `transition.ts` handler typed as `Event`; `CFocusTrap` uses `Record<string, unknown>` / `{ value: unknown }`; `ComponentProps` and `table/types` keep `any` only where required (conditional-type `infer` match, index signature) with a scoped `eslint-disable`.
- **`unicorn/consistent-function-scoping` (2)** — inlined `classNameFn` in the chip-input spec; hoisted the `nested()` helper to module scope in the nav-group spec.
- **`unicorn/no-negation-in-equality-check` (1)** — `!value === !oldValue` → `Boolean(value) === Boolean(oldValue)`.

Pure lint cleanup — no behavioral changes intended.

## Verification

- `yarn lint` — clean
- `yarn lib:test` — 628/628 passing, snapshots unchanged
- `yarn lib:build` — CJS + ESM + types compile