### PR TITLE
fix(CFormRange): rename steps prop to step so the interval applies

### DIFF
--- a/packages/coreui-vue/src/components/form/CFormRange.ts
+++ b/packages/coreui-vue/src/components/form/CFormRange.ts
@@ -33,7 +33,7 @@ const CFormRange = defineComponent({
     /**
      * Specifies the interval between legal numbers in the component.
      */
-    steps: Number,
+    step: Number,
     /**
      * The `value` attribute of component.
      *
@@ -79,7 +79,7 @@ const CFormRange = defineComponent({
           min: props.min,
           onChange: (event: InputEvent) => handleChange(event),
           readonly: props.readonly,
-          steps: props.steps,
+          step: props.step,
           type: 'range',
           value: props.modelValue,
         },

--- a/packages/coreui-vue/src/components/form/__tests__/CFormRange.spec.ts
+++ b/packages/coreui-vue/src/components/form/__tests__/CFormRange.spec.ts
@@ -16,7 +16,7 @@ const customWrapper = mount(Component, {
     max: 400,
     min: 50,
     readonly: true,
-    steps: 10,
+    step: 10,
     value: 250,
   },
   slots: {
@@ -50,6 +50,6 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('input').attributes('max')).toBe('400')
     expect(customWrapper.find('input').attributes('min')).toBe('50')
     expect(customWrapper.find('input').attributes('readonly')).toBe('')
-    expect(customWrapper.find('input').attributes('steps')).toBe('10')
+    expect(customWrapper.find('input').attributes('step')).toBe('10')
   })
 })

--- a/packages/coreui-vue/src/components/form/__tests__/__snapshots__/CFormRange.spec.ts.snap
+++ b/packages/coreui-vue/src/components/form/__tests__/__snapshots__/CFormRange.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Customize CFormRange component renders correctly 1`] = `"<input class="form-range" disabled="" max="400" min="50" readonly="" steps="10" type="range">"`;
+exports[`Customize CFormRange component renders correctly 1`] = `"<input class="form-range" disabled="" max="400" min="50" readonly="" step="10" type="range">"`;
 
 exports[`Loads and display CFormRange component renders correctly 1`] = `"<input class="form-range" type="range">"`;

--- a/packages/docs/api/form/CFormRange.api.md
+++ b/packages/docs/api/form/CFormRange.api.md
@@ -16,7 +16,7 @@ import CFormRange from '@coreui/vue/src/components/form/CFormRange'
 | **min**                                                  | Specifies the minimum value for the component.                   | number  | -      | -       |
 | **model-value**                                          | The default name for a value passed using v-model.               | string  | -      | -       |
 | **readonly**                                             | Toggle the readonly state for the component.                     | boolean | -      | -       |
-| **steps**                                                | Specifies the interval between legal numbers in the component.   | number  | -      | -       |
+| **step**                                                 | Specifies the interval between legal numbers in the component.   | number  | -      | -       |
 | **value**                                                | The `value` attribute of component.<br/>`@controllable` onChange | number  | -      | -       |
 
 #### Events


### PR DESCRIPTION
`CFormRange` declared a `steps` prop and rendered it as a `steps` attribute on the `<input type="range">`. `steps` is **not a valid attribute** for range inputs, so the step interval never applied — and the documented example on the Range page (`:step="0.5"`) silently did nothing because the matching prop didn't exist.

## Fix

- Rename the prop `steps` → `step` and render the valid `step` attribute.
- Matches `coreui-react` (`step?: number`) and the existing docs example.

## Backward compatibility

Observable behavior is unchanged for anyone who set `steps`: it was a no-op before (invalid attribute) and, now that it's undeclared, it simply falls through as the same invalid attribute. No one could have been relying on a working `steps`, because it never worked.

## Verification

- Updated `CFormRange.spec.ts` + snapshot, regenerated API table (`yarn docs:api`).
- `yarn lib:test` — 628/628 passing · `yarn lint` clean · `yarn lib:build` OK