### PR TITLE
test: cover the v-c-popover and v-c-tooltip directives

### DIFF
--- a/packages/coreui-vue/src/directives/__tests__/v-c-popover.spec.ts
+++ b/packages/coreui-vue/src/directives/__tests__/v-c-popover.spec.ts
@@ -1,0 +1,67 @@
+import { mount } from '@vue/test-utils'
+import { h, withDirectives } from 'vue'
+import { createPopper } from '@popperjs/core'
+import vCPopover from '../v-c-popover'
+
+jest.mock('@popperjs/core', () => ({ createPopper: jest.fn() }))
+
+const mockedCreatePopper = createPopper as jest.Mock
+
+const renderWithDirective = (value: unknown) =>
+  mount(
+    {
+      render: () => withDirectives(h('button', 'Trigger'), [[vCPopover, value]]),
+    },
+    { attachTo: document.body }
+  )
+
+describe('v-c-popover directive', () => {
+  afterEach(() => {
+    document.body.querySelectorAll('.popover').forEach((el) => el.remove())
+    mockedCreatePopper.mockClear()
+  })
+
+  it('creates a popover on click with header and content', async () => {
+    const wrapper = renderWithDirective({ header: 'Title', content: 'Body', trigger: 'click' })
+    await wrapper.find('button').trigger('click')
+
+    const popover = document.body.querySelector('.popover')
+    expect(popover).not.toBeNull()
+    expect(popover?.querySelector('.popover-header')?.textContent).toBe('Title')
+    expect(popover?.querySelector('.popover-body')?.textContent).toBe('Body')
+    expect(mockedCreatePopper).toHaveBeenCalled()
+  })
+
+  it('accepts a plain string value as content', async () => {
+    const wrapper = renderWithDirective('Just content')
+    await wrapper.find('button').trigger('click')
+    expect(document.body.querySelector('.popover-body')?.textContent).toBe('Just content')
+  })
+
+  it('toggles the popover off on a second click', async () => {
+    const wrapper = renderWithDirective({ content: 'Body', trigger: 'click' })
+    const button = wrapper.find('button')
+
+    await button.trigger('click')
+    const popover = document.body.querySelector('.popover')
+    popover?.classList.add('show')
+
+    await button.trigger('click')
+    expect(document.body.querySelector('.popover')?.classList.contains('show')).toBe(false)
+  })
+
+  it('shows the popover on focus for the focus trigger', async () => {
+    const wrapper = renderWithDirective({ content: 'Body', trigger: 'focus' })
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.querySelector('.popover')).not.toBeNull()
+  })
+
+  it('removes the popover element on unmount', async () => {
+    const wrapper = renderWithDirective({ content: 'Body', trigger: 'click' })
+    await wrapper.find('button').trigger('click')
+    expect(document.body.querySelector('.popover')).not.toBeNull()
+
+    wrapper.unmount()
+    expect(document.body.querySelector('.popover')).toBeNull()
+  })
+})

--- a/packages/coreui-vue/src/directives/__tests__/v-c-tooltip.spec.ts
+++ b/packages/coreui-vue/src/directives/__tests__/v-c-tooltip.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils'
+import { h, withDirectives } from 'vue'
+import { createPopper } from '@popperjs/core'
+import vCTooltip from '../v-c-tooltip'
+
+jest.mock('@popperjs/core', () => ({ createPopper: jest.fn() }))
+
+const mockedCreatePopper = createPopper as jest.Mock
+
+const renderWithDirective = (value: unknown) =>
+  mount(
+    {
+      render: () => withDirectives(h('button', 'Trigger'), [[vCTooltip, value]]),
+    },
+    { attachTo: document.body }
+  )
+
+describe('v-c-tooltip directive', () => {
+  afterEach(() => {
+    document.body.querySelectorAll('.tooltip').forEach((el) => el.remove())
+    mockedCreatePopper.mockClear()
+  })
+
+  it('creates a tooltip on hover with content', async () => {
+    const wrapper = renderWithDirective({ content: 'Hello', trigger: 'hover' })
+    await wrapper.find('button').trigger('mouseenter')
+
+    const tooltip = document.body.querySelector('.tooltip')
+    expect(tooltip).not.toBeNull()
+    expect(tooltip?.querySelector('.tooltip-inner')?.textContent).toBe('Hello')
+    expect(tooltip?.getAttribute('role')).toBe('tooltip')
+    expect(mockedCreatePopper).toHaveBeenCalled()
+  })
+
+  it('accepts a plain string value as content', async () => {
+    const wrapper = renderWithDirective('Just content')
+    await wrapper.find('button').trigger('mouseenter')
+    expect(document.body.querySelector('.tooltip-inner')?.textContent).toBe('Just content')
+  })
+
+  it('hides the tooltip on mouseleave', async () => {
+    const wrapper = renderWithDirective({ content: 'Hello', trigger: 'hover' })
+    const button = wrapper.find('button')
+
+    await button.trigger('mouseenter')
+    document.body.querySelector('.tooltip')?.classList.add('show')
+
+    await button.trigger('mouseleave')
+    expect(document.body.querySelector('.tooltip')?.classList.contains('show')).toBe(false)
+  })
+
+  it('shows the tooltip on click for the click trigger', async () => {
+    const wrapper = renderWithDirective({ content: 'Hello', trigger: 'click' })
+    await wrapper.find('button').trigger('click')
+    expect(document.body.querySelector('.tooltip')).not.toBeNull()
+  })
+
+  it('removes the tooltip element on unmount', async () => {
+    const wrapper = renderWithDirective({ content: 'Hello', trigger: 'click' })
+    await wrapper.find('button').trigger('click')
+    expect(document.body.querySelector('.tooltip')).not.toBeNull()
+
+    wrapper.unmount()
+    expect(document.body.querySelector('.tooltip')).toBeNull()
+  })
+})


### PR DESCRIPTION
Follow-up to #326 — covers the last two untested low-coverage units: the standalone `v-c-popover` and `v-c-tooltip` directives (~13% before).

## What

With `createPopper` mocked (jsdom can't lay out Popper), each spec asserts:
- the floating element is created in `document.body` with the right header/content on its configured trigger (`click` for popover, `hover` for tooltip),
- the string-value shorthand maps to `content`,
- toggle-off / hide on the second interaction,
- the alternate trigger works,
- the element is removed on unmount.

## Verification

- `yarn lib:test` — 666/666 passing (+10) · `yarn lint` clean