### PR TITLE
chore: fix library source lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,14 @@ export default typescriptEslint.config(
       },
     },
     rules: {
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        { allowShortCircuit: true, allowTernary: true },
+      ],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { args: 'after-used', argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
       'no-console': 'off',
       'no-debugger': 'off',
       'unicorn/filename-case': 'off',

--- a/packages/coreui-vue/src/types.ts
+++ b/packages/coreui-vue/src/types.ts
@@ -1,15 +1,7 @@
 export type Breakpoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
 
 export type Colors =
-  | 'primary'
-  | 'secondary'
-  | 'success'
-  | 'danger'
-  | 'warning'
-  | 'info'
-  | 'dark'
-  | 'light'
-  | string
+  'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'dark' | 'light' | string
 
 export type Placements =
   | 'auto'


### PR DESCRIPTION
Clears the pre-existing `yarn lint` debt in the Vue library source (separate from the docs-examples cleanup already merged on main).

- `@typescript-eslint/no-unused-expressions` configured with `allowShortCircuit`/`allowTernary` to match the codebase's side-effect idioms.
- `@typescript-eslint/no-unused-vars` configured with `^_` ignore pattern (and rest siblings) to match the React config.
- prettier autofix across the library source.

`yarn lint` now reports 0 errors in the library source. Lib build green.