### PR TITLE
docs(Tooltip, Popover): import directives locally in examples

### DIFF
--- a/packages/docs/src/content/docs/components/modal/examples/ModalOptionalSizesExample.vue
+++ b/packages/docs/src/content/docs/components/modal/examples/ModalOptionalSizesExample.vue
@@ -65,6 +65,8 @@ import {
   CModalBody,
   CLink,
   CModalFooter,
+  vcpopover as vCPopover,
+  vctooltip as vCTooltip,
 } from '@coreui/vue'
 import { ref } from 'vue'
 const visibleTooltipsAndPopoversDemo = ref(false)

--- a/packages/docs/src/content/docs/components/popover/examples/PopoverDisabledElementsExample.vue
+++ b/packages/docs/src/content/docs/components/popover/examples/PopoverDisabledElementsExample.vue
@@ -34,5 +34,5 @@
 </template>
 
 <script setup>
-import { CButton } from '@coreui/vue'
+import { CButton, vcpopover as vCPopover } from '@coreui/vue'
 </script>

--- a/packages/docs/src/content/docs/components/popover/examples/PopoverFourDirectionsExample.vue
+++ b/packages/docs/src/content/docs/components/popover/examples/PopoverFourDirectionsExample.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script setup>
-import { CButton } from '@coreui/vue'
+import { CButton, vcpopover as vCPopover } from '@coreui/vue'
 </script>

--- a/packages/docs/src/content/docs/components/tooltip/examples/TooltipDirectiveExample.vue
+++ b/packages/docs/src/content/docs/components/tooltip/examples/TooltipDirectiveExample.vue
@@ -34,5 +34,5 @@
 </template>
 
 <script setup>
-import { CButton } from '@coreui/vue'
+import { CButton, vctooltip as vCTooltip } from '@coreui/vue'
 </script>

--- a/packages/docs/src/content/docs/components/tooltip/examples/TooltipOnLinksExample.vue
+++ b/packages/docs/src/content/docs/components/tooltip/examples/TooltipOnLinksExample.vue
@@ -16,5 +16,5 @@
 </template>
 
 <script setup>
-import { CLink } from '@coreui/vue'
+import { CLink, vctooltip as vCTooltip } from '@coreui/vue'
 </script>


### PR DESCRIPTION
The tooltip/popover examples used the `v-c-tooltip` and `v-c-popover` directives without registering them. In the Astro docs each example is a standalone Vue island where the `CoreuiVue` plugin is not installed, so the directives never resolved and the demos did nothing.

Fix: import the directives locally in each example's `<script setup>` with an alias matching Vue's template resolution (`vctooltip as vCTooltip`, `vcpopover as vCPopover`).

Affected examples: Tooltip (Directive, OnLinks), Popover (DisabledElements, FourDirections), Modal (OptionalSizes).