### PR TITLE
feat(CAlert): add transition, closed and ariaCloseLabel

### DIFF
--- a/packages/coreui-vue/src/components/alert/CAlert.ts
+++ b/packages/coreui-vue/src/components/alert/CAlert.ts
@@ -1,8 +1,9 @@
-import { defineComponent, h, ref, Transition, watch } from 'vue'
+import { defineComponent, h, ref, RendererElement, Transition, watch } from 'vue'
 
 import { CCloseButton } from '../close-button'
 
 import { Color } from '../../props'
+import { executeAfterTransition } from '../../utils/transition'
 
 export const CAlert = defineComponent({
   name: 'CAlert',
@@ -18,6 +19,15 @@ export const CAlert = defineComponent({
      * Optionally add a close button to alert and allow it to self dismisss.
      */
     dismissible: Boolean,
+    /**
+     * Set whether the alert fades in and out when it is shown and hidden. Set to `false` to make it appear and disappear without a fade animation.
+     *
+     * @since 5.10.0
+     */
+    transition: {
+      type: Boolean,
+      default: true,
+    },
     /**
      * Set the alert variant to a solid.
      *
@@ -39,11 +49,18 @@ export const CAlert = defineComponent({
   },
   emits: [
     /**
-     * Callback fired when the component requests to be closed.
+     * Event fired when the component requests to be closed.
      */
     'close',
+    /**
+     * Event fired after the alert has been closed and the CSS transition has completed.
+     *
+     * @since 5.10.0
+     */
+    'closed',
   ],
   setup(props, { attrs, slots, emit }) {
+    const alertRef = ref<HTMLDivElement>()
     const visible = ref(props.visible)
 
     watch(
@@ -53,19 +70,36 @@ export const CAlert = defineComponent({
       }
     )
 
+    const handleEnter = (el: RendererElement, done: () => void) => {
+      executeAfterTransition(() => done(), el as HTMLElement)
+      setTimeout(() => {
+        el.classList.add('show')
+      }, 1)
+    }
+
+    const handleLeave = (el: RendererElement, done: () => void) => {
+      el.classList.remove('show')
+      executeAfterTransition(() => done(), el as HTMLElement)
+    }
+
+    const handleAfterLeave = () => {
+      emit('closed')
+    }
+
     const handleDismiss = () => {
-      visible.value = false
       emit('close')
+      visible.value = false
     }
 
     return () =>
       h(
         Transition,
         {
-          enterFromClass: '',
-          enterActiveClass: 'fade',
-          enterToClass: 'fade show',
-          leaveActiveClass: 'fade',
+          appear: true,
+          css: false,
+          onEnter: (el, done) => handleEnter(el, done),
+          onLeave: (el, done) => handleLeave(el, done),
+          onAfterLeave: () => handleAfterLeave(),
         },
         {
           default: () =>
@@ -82,9 +116,11 @@ export const CAlert = defineComponent({
                   {
                     [`alert-${props.color}`]: props.color,
                     'alert-dismissible': props.dismissible,
+                    fade: props.transition,
                   },
                   attrs.class,
                 ],
+                ref: alertRef,
               },
               [
                 slots.default && slots.default(),

--- a/packages/coreui-vue/src/components/alert/CAlert.ts
+++ b/packages/coreui-vue/src/components/alert/CAlert.ts
@@ -5,6 +5,18 @@ import { CCloseButton } from '../close-button'
 import { Color } from '../../props'
 import { executeAfterTransition } from '../../utils/transition'
 
+const handleEnter = (el: RendererElement, done: () => void) => {
+  executeAfterTransition(() => done(), el as HTMLElement)
+  setTimeout(() => {
+    el.classList.add('show')
+  }, 1)
+}
+
+const handleLeave = (el: RendererElement, done: () => void) => {
+  el.classList.remove('show')
+  executeAfterTransition(() => done(), el as HTMLElement)
+}
+
 export const CAlert = defineComponent({
   name: 'CAlert',
   inheritAttrs: false,
@@ -78,18 +90,6 @@ export const CAlert = defineComponent({
         visible.value = props.visible
       }
     )
-
-    const handleEnter = (el: RendererElement, done: () => void) => {
-      executeAfterTransition(() => done(), el as HTMLElement)
-      setTimeout(() => {
-        el.classList.add('show')
-      }, 1)
-    }
-
-    const handleLeave = (el: RendererElement, done: () => void) => {
-      el.classList.remove('show')
-      executeAfterTransition(() => done(), el as HTMLElement)
-    }
 
     const handleAfterLeave = () => {
       emit('closed')

--- a/packages/coreui-vue/src/components/alert/CAlert.ts
+++ b/packages/coreui-vue/src/components/alert/CAlert.ts
@@ -10,6 +10,15 @@ export const CAlert = defineComponent({
   inheritAttrs: false,
   props: {
     /**
+     * Sets the `aria-label` of the dismissible close button.
+     *
+     * @since 5.10.0
+     */
+    ariaCloseLabel: {
+      type: String,
+      default: 'Close',
+    },
+    /**
      * Sets the color context of the component to one of CoreUI’s themed colors.
      *
      * @values 'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light'
@@ -126,6 +135,7 @@ export const CAlert = defineComponent({
                 slots.default && slots.default(),
                 props.dismissible &&
                   h(CCloseButton, {
+                    'aria-label': props.ariaCloseLabel,
                     onClick: () => {
                       handleDismiss()
                     },

--- a/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { CAlert } from '../../'
 
 describe('CAlert', () => {
@@ -42,6 +42,43 @@ describe('CAlert', () => {
       const wrapper = mount(CAlert, { props: { color: 'primary', dismissible: true } })
       await wrapper.find('.btn-close').trigger('click')
       expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('should emit closed after the transition', async () => {
+      // <Transition> JS hooks are stubbed out by default and Vue schedules them
+      // on an animation frame — disable the stub and run rAF synchronously.
+      const raf = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((cb) => {
+          cb(0)
+          return 0
+        })
+      const wrapper = mount(CAlert, {
+        props: { color: 'primary', dismissible: true },
+        global: { stubs: { transition: false } },
+      })
+      // let the appear transition finish before dismissing
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      await flushPromises()
+
+      await wrapper.find('.btn-close').trigger('click')
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      await flushPromises()
+
+      expect(wrapper.emitted('closed')).toHaveLength(1)
+      raf.mockRestore()
+    })
+  })
+
+  describe('transition', () => {
+    it('should apply the fade class', () => {
+      const wrapper = mount(CAlert, { props: { color: 'primary' } })
+      expect(wrapper.find('.alert').classes()).toContain('fade')
+    })
+
+    it('should not apply the fade class when transition is disabled', () => {
+      const wrapper = mount(CAlert, { props: { color: 'primary', transition: false } })
+      expect(wrapper.find('.alert').classes()).not.toContain('fade')
     })
   })
 

--- a/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
@@ -38,6 +38,13 @@ describe('CAlert', () => {
       expect(wrapper.find('.btn-close').exists()).toBe(true)
     })
 
+    it('should set a custom close button label', () => {
+      const wrapper = mount(CAlert, {
+        props: { color: 'primary', dismissible: true, ariaCloseLabel: 'Zamknij' },
+      })
+      expect(wrapper.find('.btn-close').attributes('aria-label')).toBe('Zamknij')
+    })
+
     it('should close an alert', async () => {
       const wrapper = mount(CAlert, { props: { color: 'primary', dismissible: true } })
       await wrapper.find('.btn-close').trigger('click')

--- a/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
@@ -54,12 +54,10 @@ describe('CAlert', () => {
     it('should emit closed after the transition', async () => {
       // <Transition> JS hooks are stubbed out by default and Vue schedules them
       // on an animation frame — disable the stub and run rAF synchronously.
-      const raf = vi
-        .spyOn(window, 'requestAnimationFrame')
-        .mockImplementation((cb) => {
-          cb(0)
-          return 0
-        })
+      const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0)
+        return 0
+      })
       const wrapper = mount(CAlert, {
         props: { color: 'primary', dismissible: true },
         global: { stubs: { transition: false } },

--- a/packages/docs/src/api/CAlert.api.json
+++ b/packages/docs/src/api/CAlert.api.json
@@ -18,6 +18,14 @@
       "deprecated": null
     },
     {
+      "name": "transition",
+      "type": "boolean",
+      "default": "true",
+      "description": "Set whether the alert fades in and out when it is shown and hidden. Set to `false` to make it appear and disappear without a fade animation.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "variant",
       "type": "string",
       "default": null,
@@ -37,7 +45,12 @@
   "events": [
     {
       "name": "close",
-      "description": "Callback fired when the component requests to be closed.",
+      "description": "Event fired when the component requests to be closed.",
+      "properties": []
+    },
+    {
+      "name": "closed",
+      "description": "Event fired after the alert has been closed and the CSS transition has completed.",
       "properties": []
     }
   ],

--- a/packages/docs/src/api/CAlert.api.json
+++ b/packages/docs/src/api/CAlert.api.json
@@ -2,6 +2,14 @@
   "name": "CAlert",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string",
+      "default": "'Close'",
+      "description": "Sets the `aria-label` of the dismissible close button.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "color",
       "type": "Color",
       "default": null,


### PR DESCRIPTION
Adds fade control and the after-transition close event to `CAlert`, reconciling a cross-framework divergence found by the alert test-parity work.

## API
- **`transition?: boolean`** (default `true`, matching `CModal`) — controls the fade animation via a static `fade` class.
- **`closed`** event — emitted after the leave transition finishes, mirroring Bootstrap's `closed.coreui.alert` (the existing `close` event is the immediate one).

## Implementation
Reworks the component onto an idiomatic `<Transition appear :css="false">` with JS hooks (`onEnter`/`onLeave`/`onAfterLeave`) that toggle `show` and use `executeAfterTransition` for timing — the same pattern as `CModal`. `fade` is a static class bound to `transition` (not a transient transition class), so it's decoupled from `dismissible`; a non-dismissible alert now fades by default.

## Tests
Adds a `transition` group and `should emit closed after the transition`. Testing the `<Transition>` JS hook needs `stubs: { transition: false }` + a mocked `requestAnimationFrame` (per the Vue Test Utils docs). Full suite green (671 tests).

Ports the same API landed in coreui-react.