### PR TITLE
test(CAlertHeading, CAlertLink): align to canonical cross-framework cases

### DIFF
--- a/packages/coreui-vue/src/components/alert/__tests__/CAlertHeading.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlertHeading.spec.ts
@@ -1,43 +1,25 @@
 import { mount } from '@vue/test-utils'
-import { CAlertHeading as Component } from '../../../index'
+import { CAlertHeading } from '../../'
 
-const ComponentName = 'CAlertHeading'
-
-const defaultWrapper = mount(Component, {
-  propsData: {},
-  slots: {
-    default: 'Default slot',
-  },
-})
-
-const customWrapper = mount(Component, {
-  propsData: {
-    as: 'h2',
-  },
-  slots: {
-    default: 'Default slot',
-  },
-})
-
-describe(`Loads and display ${ComponentName} component`, () => {
-  it('has a name', () => {
-    expect(Component.name).toMatch(ComponentName)
+describe('CAlertHeading', () => {
+  it('should render an alert heading', () => {
+    const wrapper = mount(CAlertHeading)
+    expect(wrapper.find('.alert-heading').exists()).toBe(true)
+    expect(wrapper.element.tagName).toBe('H4')
   })
-  it('renders correctly', () => {
-    expect(defaultWrapper.html()).toMatchSnapshot()
-  })
-  it('contain slots and classes', () => {
-    expect(defaultWrapper.text()).toContain('Default slot')
-    expect(defaultWrapper.classes('alert-heading')).toBe(true)
-  })
-})
 
-describe(`Customize ${ComponentName} component`, () => {
-  it('renders correctly', () => {
-    expect(customWrapper.html()).toMatchSnapshot()
+  it('should render its content', () => {
+    const wrapper = mount(CAlertHeading, { slots: { default: 'Hello World!' } })
+    expect(wrapper.text()).toContain('Hello World!')
   })
-  it('contain slots and classes', () => {
-    expect(customWrapper.text()).toContain('Default slot')
-    expect(customWrapper.classes('alert-heading')).toBe(true)
+
+  it('should apply a custom class name', () => {
+    const wrapper = mount(CAlertHeading, { attrs: { class: 'bazinga' } })
+    expect(wrapper.find('.alert-heading').classes()).toContain('bazinga')
+  })
+
+  it('should render as a custom element', () => {
+    const wrapper = mount(CAlertHeading, { props: { as: 'h2' } })
+    expect(wrapper.element.tagName).toBe('H2')
   })
 })

--- a/packages/coreui-vue/src/components/alert/__tests__/CAlertLink.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlertLink.spec.ts
@@ -1,24 +1,20 @@
 import { mount } from '@vue/test-utils'
-import { CAlertLink as Component } from '../../../index'
+import { CAlertLink } from '../../'
 
-const ComponentName = 'CAlertLink'
-
-const defaultWrapper = mount(Component, {
-  propsData: {},
-  slots: {
-    default: 'Default slot',
-  },
-})
-
-describe(`Loads and display ${ComponentName} component`, () => {
-  it('has a name', () => {
-    expect(Component.name).toMatch(ComponentName)
+describe('CAlertLink', () => {
+  it('should render an alert link', () => {
+    const wrapper = mount(CAlertLink)
+    expect(wrapper.find('.alert-link').exists()).toBe(true)
+    expect(wrapper.element.tagName).toBe('A')
   })
-  it('renders correctly', () => {
-    expect(defaultWrapper.html()).toMatchSnapshot()
+
+  it('should render its content', () => {
+    const wrapper = mount(CAlertLink, { slots: { default: 'Hello World!' } })
+    expect(wrapper.text()).toContain('Hello World!')
   })
-  it('contain slots and classes', () => {
-    expect(defaultWrapper.text()).toContain('Default slot')
-    expect(defaultWrapper.classes('alert-link')).toBe(true)
+
+  it('should apply a custom class name', () => {
+    const wrapper = mount(CAlertLink, { attrs: { class: 'bazinga' } })
+    expect(wrapper.find('.alert-link').classes()).toContain('bazinga')
   })
 })

--- a/packages/coreui-vue/src/components/alert/__tests__/__snapshots__/CAlertHeading.spec.ts.snap
+++ b/packages/coreui-vue/src/components/alert/__tests__/__snapshots__/CAlertHeading.spec.ts.snap
@@ -1,5 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`Customize CAlertHeading component > renders correctly 1`] = `"<h2 class="alert-heading">Default slot</h2>"`;
-
-exports[`Loads and display CAlertHeading component > renders correctly 1`] = `"<h4 class="alert-heading">Default slot</h4>"`;

--- a/packages/coreui-vue/src/components/alert/__tests__/__snapshots__/CAlertLink.spec.ts.snap
+++ b/packages/coreui-vue/src/components/alert/__tests__/__snapshots__/CAlertLink.spec.ts.snap
@@ -1,3 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`Loads and display CAlertLink component > renders correctly 1`] = `"<a class="alert-link">Default slot</a>"`;


### PR DESCRIPTION
Continues the alert test-parity work down to the subcomponents. `CAlertHeading` and `CAlertLink` now use behavior-named `it()` descriptions shared **verbatim** with the React edition:

- **CAlertHeading** — should render an alert heading / should render its content / should apply a custom class name / should render as a custom element
- **CAlertLink** — should render an alert link / should render its content / should apply a custom class name

Snapshot-only coverage replaced with explicit assertions. Full suite green (671).