### PR TITLE
test(CButton): align to canonical cross-framework cases

### DIFF
--- a/packages/coreui-vue/src/components/button/__tests__/CButton.spec.ts
+++ b/packages/coreui-vue/src/components/button/__tests__/CButton.spec.ts
@@ -1,79 +1,84 @@
 import { mount } from '@vue/test-utils'
-import { CButton as Component } from '../../../index'
+import { CButton } from '../../'
 
-const ComponentName = 'CButton'
+describe('CButton', () => {
+  describe('rendering', () => {
+    it('should render a button with the base class', () => {
+      const wrapper = mount(CButton)
+      expect(wrapper.classes()).toContain('btn')
+      expect(wrapper.element.tagName).toBe('BUTTON')
+    })
 
-const defaultWrapper = mount(Component, {
-  propsData: {},
-  slots: {
-    default: 'Default slot',
-  },
-})
+    it('should render its content', () => {
+      const wrapper = mount(CButton, { slots: { default: 'Hello World!' } })
+      expect(wrapper.text()).toContain('Hello World!')
+    })
 
-const customWrapper = mount(Component, {
-  propsData: {
-    active: true,
-    as: 'div',
-    color: 'warning',
-    disabled: true,
-    href: '/bazinga',
-    shape: 'rounded-pill',
-    size: 'lg',
-    variant: 'outline',
-  },
-  slots: {
-    default: 'Default slot',
-  },
-})
+    it('should apply the color class', () => {
+      const wrapper = mount(CButton, { props: { color: 'primary' } })
+      expect(wrapper.classes()).toContain('btn-primary')
+    })
 
-const customWrapperTwo = mount(Component, {
-  propsData: {
-    as: 'a',
-    color: 'warning',
-    disabled: true,
-  },
-  slots: {
-    default: 'Default slot',
-  },
-})
+    it('should apply the variant class', () => {
+      const wrapper = mount(CButton, { props: { color: 'warning', variant: 'outline' } })
+      expect(wrapper.classes()).toContain('btn-outline-warning')
+    })
 
-describe(`Loads and display ${ComponentName} component`, () => {
-  it('has a name', () => {
-    expect(Component.name).toMatch(ComponentName)
+    it('should apply the size class', () => {
+      const wrapper = mount(CButton, { props: { size: 'lg' } })
+      expect(wrapper.classes()).toContain('btn-lg')
+    })
+
+    it('should apply the shape class', () => {
+      const wrapper = mount(CButton, { props: { shape: 'rounded-pill' } })
+      expect(wrapper.classes()).toContain('rounded-pill')
+    })
+
+    it('should apply a custom class name', () => {
+      const wrapper = mount(CButton, { attrs: { class: 'bazinga' } })
+      expect(wrapper.classes()).toContain('bazinga')
+    })
   })
-  it('renders correctly', () => {
-    expect(defaultWrapper.html()).toMatchSnapshot()
-  })
-  it('contain slots and classes', () => {
-    expect(defaultWrapper.text()).toContain('Default slot')
-    expect(defaultWrapper.classes('btn')).toBe(true)
-  })
-})
 
-describe(`Customize ${ComponentName} component`, () => {
-  it('renders correctly', () => {
-    expect(customWrapper.html()).toMatchSnapshot()
-  })
-  it('contain slots and classes', () => {
-    expect(customWrapper.text()).toContain('Default slot')
-    expect(customWrapper.classes('btn-outline-warning')).toBe(true)
-    expect(customWrapper.classes('btn-lg')).toBe(true)
-    expect(customWrapper.classes('active')).toBe(true)
-    expect(customWrapper.classes('disabled')).toBe(true)
-    expect(customWrapper.classes('rounded-pill')).toBe(true)
-    expect(customWrapper.classes('btn')).toBe(true)
-  })
-})
+  describe('states', () => {
+    it('should apply the active class', () => {
+      const wrapper = mount(CButton, { props: { active: true } })
+      expect(wrapper.classes()).toContain('active')
+    })
 
-describe(`Customize (number two) ${ComponentName} component`, () => {
-  it('renders correctly', () => {
-    expect(customWrapperTwo.html()).toMatchSnapshot()
+    it('should be disabled', () => {
+      const wrapper = mount(CButton, { props: { disabled: true } })
+      expect(wrapper.attributes('disabled')).toBeDefined()
+    })
+
+    it('should emit a click event', async () => {
+      const wrapper = mount(CButton)
+      await wrapper.trigger('click')
+      expect(wrapper.emitted('click')).toHaveLength(1)
+    })
+
+    it('should not emit a click event when disabled', async () => {
+      const wrapper = mount(CButton, { props: { disabled: true } })
+      await wrapper.trigger('click')
+      expect(wrapper.emitted('click')).toBeUndefined()
+    })
   })
-  it('contain slots and classes', () => {
-    expect(customWrapperTwo.text()).toContain('Default slot')
-    expect(customWrapperTwo.classes('disabled')).toBe(true)
-    expect(customWrapperTwo.classes('btn')).toBe(true)
-    expect(customWrapperTwo.attributes('aria-disabled')).toBe('true')
-    expect(customWrapperTwo.attributes('tabindex')).toBe('-1')
+
+  describe('element', () => {
+    it('should set the button type', () => {
+      const wrapper = mount(CButton)
+      expect(wrapper.attributes('type')).toBe('button')
+    })
+
+    it('should render as a custom element', () => {
+      const wrapper = mount(CButton, { props: { as: 'span' } })
+      expect(wrapper.element.tagName).toBe('SPAN')
+    })
+
+    it('should render as a link when href is set', () => {
+      const wrapper = mount(CButton, { props: { href: '/test' } })
+      expect(wrapper.element.tagName).toBe('A')
+      expect(wrapper.attributes('href')).toBe('/test')
+    })
   })
 })

--- a/packages/coreui-vue/src/components/button/__tests__/__snapshots__/CButton.spec.ts.snap
+++ b/packages/coreui-vue/src/components/button/__tests__/__snapshots__/CButton.spec.ts.snap
@@ -1,7 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`Customize (number two) CButton component > renders correctly 1`] = `"<a class="btn btn-warning disabled" aria-disabled="true" tabindex="-1">Default slot</a>"`;
-
-exports[`Customize CButton component > renders correctly 1`] = `"<a class="btn btn-outline-warning btn-lg active disabled rounded-pill" aria-disabled="true" tabindex="-1" href="/bazinga">Default slot</a>"`;
-
-exports[`Loads and display CButton component > renders correctly 1`] = `"<button class="btn" type="button">Default slot</button>"`;


### PR DESCRIPTION
Next component in the cross-framework test-parity effort (registry: private dev-workspace `architecture/components/button/tests.md`). Following vanilla component order (alert → button).

`CButton` now uses behavior-named `it()` descriptions shared **verbatim** with React, grouped:
- **rendering** — base class, content, color, variant, size, shape, custom class
- **states** — active, disabled, click, no-click-when-disabled
- **element** — type, custom element (`as`), link (`href`)

Snapshot-only coverage replaced with explicit assertions. No component divergences surfaced. Full suite green (678).