### PR TITLE
feat(CButton): add toggle prop and set type on input buttons

### DIFF
--- a/packages/coreui-vue/src/components/button/CButton.ts
+++ b/packages/coreui-vue/src/components/button/CButton.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, ref, watch } from 'vue'
 
 import { Color, Shape } from '../../props'
 
@@ -48,6 +48,12 @@ export const CButton = defineComponent({
       },
     },
     /**
+     * Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.
+     *
+     * @since 5.10.0
+     */
+    toggle: Boolean,
+    /**
      * Specifies the type of button. Always specify the type attribute for the `<button>` element.
      * Different browsers may use different default types for the `<button>` element.
      *
@@ -80,9 +86,23 @@ export const CButton = defineComponent({
   ],
   setup(props, { emit, slots }) {
     const component = props.href ? 'a' : props.as
+    const active = ref(props.active)
+
+    watch(
+      () => props.active,
+      () => {
+        active.value = props.active
+      }
+    )
+
     const handleClick = (event: Event) => {
       if (props.disabled) {
         return
+      }
+
+      if (props.toggle) {
+        event.preventDefault()
+        active.value = !active.value
       }
 
       emit('click', event)
@@ -98,14 +118,18 @@ export const CButton = defineComponent({
               [`btn-${props.variant}`]: !props.color && props.variant,
               [`btn-${props.color}`]: props.color && !props.variant,
               [`btn-${props.size}`]: props.size,
-              active: props.active,
+              active: active.value,
               disabled: props.disabled,
             },
             props.shape,
           ],
+          ...(props.toggle && { 'aria-pressed': active.value }),
           ...(component === 'a' && props.disabled && { 'aria-disabled': true, tabIndex: -1 }),
           ...(component === 'a' && props.href && { href: props.href }),
-          ...(component === 'button' && { type: props.type, disabled: props.disabled }),
+          ...((component === 'button' || component === 'input') && {
+            type: props.type,
+            disabled: props.disabled,
+          }),
           onClick: handleClick,
         },
         slots.default && slots.default()

--- a/packages/coreui-vue/src/components/button/__tests__/CButton.spec.ts
+++ b/packages/coreui-vue/src/components/button/__tests__/CButton.spec.ts
@@ -46,6 +46,40 @@ describe('CButton', () => {
       expect(wrapper.classes()).toContain('active')
     })
 
+    it('should forward the aria-pressed attribute', () => {
+      // toggle buttons opt in to aria-pressed themselves (it is not implied by active)
+      const wrapper = mount(CButton, {
+        props: { active: true },
+        attrs: { 'aria-pressed': 'true' },
+      })
+      expect(wrapper.attributes('aria-pressed')).toBe('true')
+    })
+
+    it('should toggle the active state on click', async () => {
+      const wrapper = mount(CButton, { props: { toggle: true } })
+      expect(wrapper.classes()).not.toContain('active')
+      expect(wrapper.attributes('aria-pressed')).toBe('false')
+      await wrapper.trigger('click')
+      expect(wrapper.classes()).toContain('active')
+      expect(wrapper.attributes('aria-pressed')).toBe('true')
+      await wrapper.trigger('click')
+      expect(wrapper.classes()).not.toContain('active')
+      expect(wrapper.attributes('aria-pressed')).toBe('false')
+    })
+
+    it('should seed the toggle state from the active prop', () => {
+      const wrapper = mount(CButton, { props: { toggle: true, active: true } })
+      expect(wrapper.classes()).toContain('active')
+      expect(wrapper.attributes('aria-pressed')).toBe('true')
+    })
+
+    it('should prevent the default action on a toggle click', () => {
+      const wrapper = mount(CButton, { props: { as: 'a', href: '#', toggle: true } })
+      const event = new Event('click', { cancelable: true })
+      wrapper.element.dispatchEvent(event)
+      expect(event.defaultPrevented).toBe(true)
+    })
+
     it('should be disabled', () => {
       const wrapper = mount(CButton, { props: { disabled: true } })
       expect(wrapper.attributes('disabled')).toBeDefined()
@@ -73,6 +107,15 @@ describe('CButton', () => {
     it('should render as a custom element', () => {
       const wrapper = mount(CButton, { props: { as: 'span' } })
       expect(wrapper.element.tagName).toBe('SPAN')
+    })
+
+    it('should render as an input with the button type', () => {
+      const wrapper = mount(CButton, {
+        props: { as: 'input', type: 'submit' },
+        attrs: { value: 'Submit' },
+      })
+      expect(wrapper.element.tagName).toBe('INPUT')
+      expect(wrapper.attributes('type')).toBe('submit')
     })
 
     it('should render as a link when href is set', () => {

--- a/packages/docs/src/api/CButton.api.json
+++ b/packages/docs/src/api/CButton.api.json
@@ -58,6 +58,14 @@
       "deprecated": null
     },
     {
+      "name": "toggle",
+      "type": "boolean",
+      "default": null,
+      "description": "Make the button behave as a toggle button. It manages its own active/pressed state, toggling it on click and reflecting it via the `aria-pressed` attribute.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "type",
       "type": "string",
       "default": "'button'",

--- a/packages/docs/src/content/docs/components/button/examples/ButtonToggleExample.vue
+++ b/packages/docs/src/content/docs/components/button/examples/ButtonToggleExample.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex gap-1 mb-3">
+    <CButton toggle>Toggle button</CButton>
+    <CButton toggle active>Active toggle button</CButton>
+    <CButton toggle disabled>Disabled toggle button</CButton>
+  </div>
+  <div class="d-flex gap-1">
+    <CButton color="primary" toggle>Toggle button</CButton>
+    <CButton color="primary" toggle active>Active toggle button</CButton>
+    <CButton color="primary" toggle disabled>Disabled toggle button</CButton>
+  </div>
+</template>
+
+<script setup>
+import { CButton } from '@coreui/vue'
+</script>

--- a/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.vue
+++ b/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex gap-1 mb-3">
+    <CButton as="a" href="#" role="button" toggle>Toggle link</CButton>
+    <CButton as="a" href="#" role="button" toggle active>Active toggle link</CButton>
+    <CButton as="a" role="button" toggle disabled>Disabled toggle link</CButton>
+  </div>
+  <div class="d-flex gap-1">
+    <CButton color="primary" as="a" href="#" role="button" toggle>Toggle link</CButton>
+    <CButton color="primary" as="a" href="#" role="button" toggle active>Active toggle link</CButton>
+    <CButton color="primary" as="a" role="button" toggle disabled>Disabled toggle link</CButton>
+  </div>
+</template>
+
+<script setup>
+import { CButton } from '@coreui/vue'
+</script>

--- a/packages/docs/src/content/docs/components/button/index.mdx
+++ b/packages/docs/src/content/docs/components/button/index.mdx
@@ -36,6 +36,10 @@ import ButtonBlock3Example from './examples/ButtonBlock3Example.vue'
 import ButtonBlock3ExampleRaw from './examples/ButtonBlock3Example.vue?raw'
 import ButtonBlock4Example from './examples/ButtonBlock4Example.vue'
 import ButtonBlock4ExampleRaw from './examples/ButtonBlock4Example.vue?raw'
+import ButtonToggleExample from './examples/ButtonToggleExample.vue'
+import ButtonToggleExampleRaw from './examples/ButtonToggleExample.vue?raw'
+import ButtonToggleLinkExample from './examples/ButtonToggleLinkExample.vue'
+import ButtonToggleLinkExampleRaw from './examples/ButtonToggleLinkExample.vue?raw'
 
 ## Examples
 
@@ -171,6 +175,24 @@ Additional utilities can be used to adjust the alignment of buttons when horizon
 
 <Example code={ButtonBlock4ExampleRaw} name="ButtonBlock4Example">
   <ButtonBlock4Example client:only="vue" />
+</Example>
+
+## Toggle states
+
+Add the `toggle` boolean prop to create simple on/off toggle buttons. A toggle button manages its own state: on click it flips the `.active` class and the `aria-pressed` attribute. Seed the initial state with the `active` prop.
+
+<Callout color="info">
+Visually, these toggle buttons are identical to the [checkbox toggle buttons](/forms/checks-radios/#checkbox-toggle-buttons). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as "checked"/"not checked" (since, despite their appearance, they are fundamentally still checkboxes), whereas these toggle buttons will be announced as "button"/"button pressed". The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
+</Callout>
+
+<Example code={ButtonToggleExampleRaw} name="ButtonToggleExample">
+  <ButtonToggleExample client:only="vue" />
+</Example>
+
+Toggle links behave the same way:
+
+<Example code={ButtonToggleLinkExampleRaw} name="ButtonToggleLinkExample">
+  <ButtonToggleLinkExample client:only="vue" />
 </Example>
 
 ## API


### PR DESCRIPTION
## Toggle buttons

Adds a `toggle` boolean prop that turns `CButton` into a self-managed toggle button, mirroring vanilla's `data-coreui-toggle="button"` plugin:

- seeds its active state from the `active` prop,
- flips it on click,
- reflects the state via the `.active` class and `aria-pressed`.

Without `toggle`, `active` stays purely visual (no implied `aria-pressed`), matching vanilla where a plain `.active` button carries no `aria-pressed`.

## Fixes

- Sets the `type` attribute when rendering as an `<input>` (previously dropped).

## Docs & tests

- New "Toggle states" docs section with button and link examples, matching the vanilla page.
- Canonical parity tests shared verbatim with `coreui-react` (toggle on click, seed from `active`, aria-pressed forwarding, input type).
- Regenerated API tables.

`@since 5.10.0`