### PR TITLE
docs: fix prettier formatting in ButtonToggleLinkExample

### DIFF
--- a/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.vue
+++ b/packages/docs/src/content/docs/components/button/examples/ButtonToggleLinkExample.vue
@@ -6,7 +6,9 @@
   </div>
   <div class="d-flex gap-1">
     <CButton color="primary" as="a" href="#" role="button" toggle>Toggle link</CButton>
-    <CButton color="primary" as="a" href="#" role="button" toggle active>Active toggle link</CButton>
+    <CButton color="primary" as="a" href="#" role="button" toggle active
+      >Active toggle link</CButton
+    >
     <CButton color="primary" as="a" role="button" toggle disabled>Disabled toggle link</CButton>
   </div>
 </template>


### PR DESCRIPTION
Fixes the `prettier/prettier` lint error on line 9 of `ButtonToggleLinkExample.vue` — the long `CButton` line now wraps per the Prettier print width.