### PR TITLE
feat(CCloseButton, CModalHeader, CToastHeader): allow customizing the close button aria-label

### DIFF
--- a/packages/coreui-vue/src/components/close-button/CCloseButton.ts
+++ b/packages/coreui-vue/src/components/close-button/CCloseButton.ts
@@ -4,6 +4,15 @@ export const CCloseButton = defineComponent({
   name: 'CCloseButton',
   props: {
     /**
+     * Sets the `aria-label` attribute of the close button.
+     *
+     * @since 5.10.0
+     */
+    ariaLabel: {
+      type: String,
+      default: 'Close',
+    },
+    /**
      * Invert the default color.
      */
     dark: Boolean,
@@ -41,7 +50,7 @@ export const CCloseButton = defineComponent({
           },
           props.disabled,
         ],
-        'aria-label': 'Close',
+        'aria-label': props.ariaLabel,
         disabled: props.disabled,
         ...(props.dark && { 'data-coreui-theme': 'dark' }),
         onClick: handleClick,

--- a/packages/coreui-vue/src/components/close-button/__tests__/CCloseButton.spec.ts
+++ b/packages/coreui-vue/src/components/close-button/__tests__/CCloseButton.spec.ts
@@ -46,3 +46,12 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.attributes('disabled')).toBe('')
   })
 })
+
+it('CCloseButton allows overriding the default aria-label', () => {
+  const wrapper = mount(Component, {
+    propsData: {
+      ariaLabel: 'Dismiss',
+    },
+  })
+  expect(wrapper.attributes('aria-label')).toBe('Dismiss')
+})

--- a/packages/coreui-vue/src/components/modal/CModalHeader.ts
+++ b/packages/coreui-vue/src/components/modal/CModalHeader.ts
@@ -6,6 +6,12 @@ const CModalHeader = defineComponent({
   name: 'CModalHeader',
   props: {
     /**
+     * Sets the `aria-label` of the close button.
+     *
+     * @since 5.10.0
+     */
+    ariaCloseLabel: String,
+    /**
      * Add a close button component to the header.
      */
     closeButton: {
@@ -22,6 +28,7 @@ const CModalHeader = defineComponent({
           h(
             CCloseButton,
             {
+              ariaLabel: props.ariaCloseLabel,
               onClick: () => {
                 visible.value = false
               },

--- a/packages/coreui-vue/src/components/modal/__tests__/CModalHeader.spec.ts
+++ b/packages/coreui-vue/src/components/modal/__tests__/CModalHeader.spec.ts
@@ -43,3 +43,13 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('button').classes('btn-close')).toBe(true)
   })
 })
+
+it('CModalHeader sets the aria-label of the close button via ariaCloseLabel', () => {
+  const wrapper = mount(Component, {
+    propsData: {
+      ariaCloseLabel: 'Dismiss',
+      closeButton: true,
+    },
+  })
+  expect(wrapper.find('button').attributes('aria-label')).toBe('Dismiss')
+})

--- a/packages/coreui-vue/src/components/toast/CToastHeader.ts
+++ b/packages/coreui-vue/src/components/toast/CToastHeader.ts
@@ -5,6 +5,12 @@ const CToastHeader = defineComponent({
   name: 'CToastHeader',
   props: {
     /**
+     * Sets the `aria-label` of the close button.
+     *
+     * @since 5.10.0
+     */
+    ariaCloseLabel: String,
+    /**
      * Automatically add a close button to the header.
      */
     closeButton: Boolean,
@@ -13,7 +19,7 @@ const CToastHeader = defineComponent({
     return () =>
       h('div', { class: 'toast-header' }, [
         slots.default && slots.default(),
-        props.closeButton && h(CToastClose),
+        props.closeButton && h(CToastClose, { ariaLabel: props.ariaCloseLabel }),
       ])
   },
 })

--- a/packages/coreui-vue/src/components/toast/__tests__/CToastHeader.spec.ts
+++ b/packages/coreui-vue/src/components/toast/__tests__/CToastHeader.spec.ts
@@ -52,3 +52,18 @@ describe(`Customize ${ComponentName} component`, () => {
     expect(customWrapper.find('button').classes('btn-close')).toBe(true)
   })
 })
+
+it('CToastHeader sets the aria-label of the close button via ariaCloseLabel', () => {
+  const wrapper = mount(Component, {
+    global: {
+      provide: {
+        updateVisible: updateVisible,
+      },
+    },
+    propsData: {
+      ariaCloseLabel: 'Dismiss',
+      closeButton: true,
+    },
+  })
+  expect(wrapper.find('button').attributes('aria-label')).toBe('Dismiss')
+})

--- a/packages/docs/src/api/CCloseButton.api.json
+++ b/packages/docs/src/api/CCloseButton.api.json
@@ -2,6 +2,14 @@
   "name": "CCloseButton",
   "props": [
     {
+      "name": "ariaLabel",
+      "type": "string",
+      "default": "'Close'",
+      "description": "Sets the `aria-label` attribute of the close button.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "dark",
       "type": "boolean",
       "default": null,

--- a/packages/docs/src/api/CModalHeader.api.json
+++ b/packages/docs/src/api/CModalHeader.api.json
@@ -2,6 +2,14 @@
   "name": "CModalHeader",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string",
+      "default": null,
+      "description": "Sets the `aria-label` of the close button.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "closeButton",
       "type": "boolean",
       "default": "true",

--- a/packages/docs/src/api/CToastHeader.api.json
+++ b/packages/docs/src/api/CToastHeader.api.json
@@ -2,6 +2,14 @@
   "name": "CToastHeader",
   "props": [
     {
+      "name": "ariaCloseLabel",
+      "type": "string",
+      "default": null,
+      "description": "Sets the `aria-label` of the close button.",
+      "since": "5.10.0",
+      "deprecated": null
+    },
+    {
       "name": "closeButton",
       "type": "boolean",
       "default": null,


### PR DESCRIPTION
`CCloseButton` rendered a hardcoded `aria-label="Close"`, so the label couldn't be localized through `CModalHeader closeButton` or `CToastHeader closeButton`.

- **CCloseButton** — new `ariaLabel` prop with a `'Close'` default (usable as `aria-label="…"` in templates thanks to prop name camelization), rendered as the button's `aria-label` attribute.
- **CModalHeader / CToastHeader** — new `ariaCloseLabel` prop (mirrors the existing `CAlert.ariaCloseLabel`, `@since 5.10.0`) passed through to the embedded close button.
- Tests added with descriptions matching the React counterparts (coreui/coreui-react#497); API JSON regenerated.