### PR TITLE
fix(CModalHeader): render a div instead of a span

### DIFF
--- a/packages/coreui-vue/src/components/modal/CModalHeader.ts
+++ b/packages/coreui-vue/src/components/modal/CModalHeader.ts
@@ -22,7 +22,7 @@ const CModalHeader = defineComponent({
   setup(props, { slots }) {
     const visible = inject<Ref<boolean>>('visible')!
     return () =>
-      h('span', { class: 'modal-header' }, [
+      h('div', { class: 'modal-header' }, [
         slots.default && slots.default(),
         props.closeButton &&
           h(

--- a/packages/coreui-vue/src/components/modal/__tests__/__snapshots__/CModalHeader.spec.ts.snap
+++ b/packages/coreui-vue/src/components/modal/__tests__/__snapshots__/CModalHeader.spec.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Customize CModalHeader component > renders correctly 1`] = `"<span class="modal-header">Default slot<button type="button" class="btn btn-close" aria-label="Close"></button></span>"`;
+exports[`Customize CModalHeader component > renders correctly 1`] = `"<div class="modal-header">Default slot<button type="button" class="btn btn-close" aria-label="Close"></button></div>"`;
 
-exports[`Loads and display CModalHeader component > renders correctly 1`] = `"<span class="modal-header">Default slot<button type="button" class="btn btn-close" aria-label="Close"></button></span>"`;
+exports[`Loads and display CModalHeader component > renders correctly 1`] = `"<div class="modal-header">Default slot<button type="button" class="btn btn-close" aria-label="Close"></button></div>"`;


### PR DESCRIPTION
`CModalHeader` rendered its root as a `<span class="modal-header">`, diverging from every other edition and every sibling header component. Bootstrap's `.modal-header` is a block-level flex container, and:

- the vanilla source of truth uses a `<div>`,
- the React edition (`CModalHeader`) uses a `<div>`,
- every other Vue header (`CToastHeader`, `COffcanvasHeader`, `CSidebarHeader`) already uses a `<div>`.

Switched the root element to `<div>` and refreshed the snapshot. Tests pass.