### PR TITLE
docs: fix doubled base path in AI Tools LLMs.txt links

### DIFF
--- a/packages/docs/src/content/docs/ai-tools/llms-txt.mdx
+++ b/packages/docs/src/content/docs/ai-tools/llms-txt.mdx
@@ -8,22 +8,22 @@ description: "LLM-optimized documentation endpoints for CoreUI for Vue — llms.
 
 [llms.txt](https://llmstxt.org) is an emerging standard that helps AI models understand and navigate documentation. The CoreUI for Vue docs expose three LLM-friendly endpoints so assistants can retrieve accurate, up-to-date content straight from the source.
 
-For a richer, tool-based integration, see [MCP Server](/vue/docs/ai-tools/mcp/).
+For a richer, tool-based integration, see [MCP Server](/ai-tools/mcp/).
 
 ## /llms.txt
 
 A structured index of the documentation — every page as a titled, described link, grouped by section. It gives an LLM a compact map of what exists and where.
 
-[Open llms.txt](/vue/docs/llms.txt)
+[Open llms.txt](/llms.txt)
 
 ## /llms-full.txt
 
 The entire documentation concatenated into a single Markdown file, so a model can ingest the whole set in one request.
 
-[Open llms-full.txt](/vue/docs/llms-full.txt)
+[Open llms-full.txt](/llms-full.txt)
 
 ## Markdown version of any page
 
 Append `.md` to any documentation page URL to get its clean Markdown version, without the site chrome.
 
-For example: [/vue/docs/components/accordion.md](/vue/docs/components/accordion.md)
+For example: [/vue/docs/components/accordion.md](/components/accordion.md)


### PR DESCRIPTION
The AI Tools -> LLMs.txt page linked its endpoints with the full `/<framework>/docs/...` prefix. The docs engine already base-prefixes root-absolute links, so they doubled (e.g. `/bootstrap/docs/bootstrap/docs/llms.txt`). Fixed by making the hrefs base-relative (`/llms.txt`, `/llms-full.txt`, `/ai-tools/mcp/`, `/components/accordion.md`). Verified with a docs build.