### PR TITLE
docs: fix broken internal links + add floating-labels API page

### DIFF
--- a/packages/docs/src/content/docs/forms/floating-labels/api.mdx
+++ b/packages/docs/src/content/docs/forms/floating-labels/api.mdx
@@ -1,0 +1,11 @@
+---
+title: "Vue Form Floating Labels Component API"
+name: "Form Floating Labels API"
+description: "Explore the API reference for the Vue Form Floating Labels component and discover how to effectively utilize its props for customization."
+---
+
+import CFormFloatingData from '@api/CFormFloating.api.json'
+
+## CFormFloating
+
+<Api data={CFormFloatingData} />

--- a/packages/docs/src/content/docs/layout/grid/index.mdx
+++ b/packages/docs/src/content/docs/layout/grid/index.mdx
@@ -45,7 +45,7 @@ The above example creates three equal-width columns across all devices and viewp
 
 Breaking it down, here's how the grid system comes together:
 
-- **Our grid supports [six responsive breakpoints](./breakpoints).**  Breakpoints are based on `min-width` media queries, meaning they affect that breakpoint and all those above it (e.g., `sm="4"` applies to `sm`, `md`, `lg`, `xl`, and `xxl`). This means you can control container and column sizing and behavior by each breakpoint.
+- **Our grid supports [six responsive breakpoints](../breakpoints).**  Breakpoints are based on `min-width` media queries, meaning they affect that breakpoint and all those above it (e.g., `sm="4"` applies to `sm`, `md`, `lg`, `xl`, and `xxl`). This means you can control container and column sizing and behavior by each breakpoint.
 
 - **Containers center and horizontally pad your content.** Use `<CContainer>` for a responsive pixel width, `<CContainer fluid>` for `width: 100%` across all viewports and devices, or a responsive container (e.g., `<CContainer md>`) for a combination of fluid and pixel widths.
 
@@ -129,7 +129,7 @@ As noted above, each of these breakpoints have their own container, unique class
     </tr>
     <tr>
       <th class="text-nowrap" scope="row">Custom gutters</th>
-      <td colspan="6"><a href="./layout/gutters">Yes</a></td>
+      <td colspan="6"><a href="../gutters">Yes</a></td>
     </tr>
     <tr>
       <th class="text-nowrap" scope="row">Nestable</th>
@@ -137,7 +137,7 @@ As noted above, each of these breakpoints have their own container, unique class
     </tr>
     <tr>
       <th class="text-nowrap" scope="row">Column ordering</th>
-      <td colspan="6"><a href="./layout/columns">Yes</a></td>
+      <td colspan="6"><a href="../columns">Yes</a></td>
     </tr>
   </tbody>
 </table>

--- a/packages/docs/src/content/docs/layout/gutters/index.mdx
+++ b/packages/docs/src/content/docs/layout/gutters/index.mdx
@@ -57,7 +57,7 @@ An alternative solution is to add a wrapper around the `<CRow>` with the `.overf
 
 ## Row columns gutters
 
-Gutter props can also be added to [row columns](../layout/grid#row-columns). In the following example, we use responsive row columns and responsive gutter props.
+Gutter props can also be added to [row columns](../grid#row-columns). In the following example, we use responsive row columns and responsive gutter props.
 
 <Example code={GuttersRowColumnsGuttersExampleRaw} name="GuttersRowColumnsGuttersExample">
   <GuttersRowColumnsGuttersExample client:only="vue" />


### PR DESCRIPTION
Fixes broken internal links surfaced by astro-broken-links-checker:

- `layout/grid` -> off-by-one relative links to sibling layout pages (`./breakpoints` -> `../breakpoints`, `./layout/gutters` -> `../gutters`, `./layout/columns` -> `../columns`).
- `layout/gutters` -> `../layout/grid#row-columns` -> `../grid#row-columns`.
- Add the missing `forms/floating-labels/api.mdx` (CFormFloating API page) so the "API" link resolves — parity with React.