### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.0-beta.12

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^6.0.3",
     "@astrojs/vue": "^5.1.4",
-    "@coreui/astro-docs": "0.1.0-beta.10",
+    "@coreui/astro-docs": "0.1.0-beta.12",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.8.0",
     "@coreui/icons": "^3.1.0",


### PR DESCRIPTION
Bumps the shared docs engine pin to `0.1.0-beta.12` (exact — pre-1.0).