### PR TITLE
fix(directives): render tooltip/popover content as text to prevent XSS

### DIFF
--- a/packages/coreui-vue/src/directives/__tests__/v-c-popover.spec.ts
+++ b/packages/coreui-vue/src/directives/__tests__/v-c-popover.spec.ts
@@ -65,4 +65,23 @@ describe('v-c-popover directive', () => {
     wrapper.unmount()
     expect(document.body.querySelector('.popover')).toBeNull()
   })
+
+  it('does not inject markup from header or content (XSS)', async () => {
+    const wrapper = renderWithDirective({
+      header: '<img src=x onerror="window.__xss=1">',
+      content: '<script>window.__xss=1</script>',
+      trigger: 'click',
+    })
+    await wrapper.find('button').trigger('click')
+
+    const popover = document.body.querySelector('.popover')
+    expect(popover?.querySelector('img')).toBeNull()
+    expect(popover?.querySelector('script')).toBeNull()
+    expect(popover?.querySelector('.popover-header')?.textContent).toBe(
+      '<img src=x onerror="window.__xss=1">'
+    )
+    expect(popover?.querySelector('.popover-body')?.textContent).toBe(
+      '<script>window.__xss=1</script>'
+    )
+  })
 })

--- a/packages/coreui-vue/src/directives/__tests__/v-c-tooltip.spec.ts
+++ b/packages/coreui-vue/src/directives/__tests__/v-c-tooltip.spec.ts
@@ -64,4 +64,18 @@ describe('v-c-tooltip directive', () => {
     wrapper.unmount()
     expect(document.body.querySelector('.tooltip')).toBeNull()
   })
+
+  it('does not inject markup from content (XSS)', async () => {
+    const wrapper = renderWithDirective({
+      content: '<img src=x onerror="window.__xss=1">',
+      trigger: 'click',
+    })
+    await wrapper.find('button').trigger('click')
+
+    const tooltip = document.body.querySelector('.tooltip')
+    expect(tooltip?.querySelector('img')).toBeNull()
+    expect(tooltip?.querySelector('.tooltip-inner')?.textContent).toBe(
+      '<img src=x onerror="window.__xss=1">'
+    )
+  })
 })

--- a/packages/coreui-vue/src/directives/v-c-popover.ts
+++ b/packages/coreui-vue/src/directives/v-c-popover.ts
@@ -9,9 +9,20 @@ const createPopoverElement = (id: string, header: string, content: string): HTML
   popover.id = id
   popover.classList.add('popover', 'bs-popover-auto', 'fade')
   popover.setAttribute('role', 'popover')
-  popover.innerHTML = `<div class="popover-arrow" data-popper-arrow></div>
-     <div class="popover-header">${header}</div>
-     <div class="popover-body" id="">${content}</div>`
+
+  const arrow = document.createElement('div')
+  arrow.classList.add('popover-arrow')
+  arrow.dataset.popperArrow = ''
+
+  const headerElement = document.createElement('div')
+  headerElement.classList.add('popover-header')
+  headerElement.textContent = header
+
+  const body = document.createElement('div')
+  body.classList.add('popover-body')
+  body.textContent = content
+
+  popover.append(arrow, headerElement, body)
   return popover
 }
 

--- a/packages/coreui-vue/src/directives/v-c-tooltip.ts
+++ b/packages/coreui-vue/src/directives/v-c-tooltip.ts
@@ -9,8 +9,16 @@ const createTooltipElement = (id: string, content: string): HTMLDivElement => {
   tooltip.id = id
   tooltip.classList.add('tooltip', 'bs-tooltip-auto', 'fade')
   tooltip.setAttribute('role', 'tooltip')
-  tooltip.innerHTML = `<div class="tooltip-arrow" data-popper-arrow></div>
-     <div class="tooltip-inner" id="">${content}</div>`
+
+  const arrow = document.createElement('div')
+  arrow.classList.add('tooltip-arrow')
+  arrow.dataset.popperArrow = ''
+
+  const inner = document.createElement('div')
+  inner.classList.add('tooltip-inner')
+  inner.textContent = content
+
+  tooltip.append(arrow, inner)
   return tooltip
 }
 


### PR DESCRIPTION
## Security fix — `v-c-tooltip` / `v-c-popover` directive XSS

Both directives wrote the binding content (and the popover header) straight into `innerHTML` with no sanitizer — unlike the vanilla tooltip, which sanitizes with an allow list. A value such as `<img src=x onerror=…>` executed.

### Fix
Build the tooltip/popover structure with DOM nodes and set content via `textContent`, matching Bootstrap's `html: false` default. All documented usage passes plain-text content, so rendering is unchanged.

Regression tests added.