### PR TITLE
chore(package): sideEffects + exclude tests from tarball

### DIFF
--- a/packages/coreui-vue/package.json
+++ b/packages/coreui-vue/package.json
@@ -31,6 +31,7 @@
     "dist/",
     "src/"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "npm-run-all clean build-*",
     "build-cjs": "rollup --environment ESM:false --config",

--- a/packages/coreui-vue/package.json
+++ b/packages/coreui-vue/package.json
@@ -29,7 +29,8 @@
   "types": "dist/esm/index.d.ts",
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "!src/**/__tests__"
   ],
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
## Packaging fixes (from the July 2026 packaging audit)

### Top-5 #2 — `sideEffects`
Added `"sideEffects": false` (react/react-pro already have it; vue had no field, so webpack retained the whole `index → components/*` re-export chain in consumer bundles). Verified safe: ESM build is `preserveModules`, `src` has 0 CSS/SCSS imports and 0 import-time side-effect imports.

### Top-5 #5 — stop shipping tests
The `"src/"` whitelist shipped ~250 test + snapshot files with zero consumer value. Added `"!src/**/__tests__"`. Verified via `npm pack --dry-run`: 0 test files remaining, `dist/` untouched.

Metadata-only; no source touched.