### PR TITLE
fix(useColorModes): remove the matchMedia listener on unmount

### DIFF
--- a/packages/coreui-vue/src/composables/__tests__/useColorModes.spec.ts
+++ b/packages/coreui-vue/src/composables/__tests__/useColorModes.spec.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { useColorModes } from '../useColorModes'
+
+const setupEnv = () => {
+  const addEventListener = vi.fn()
+  const removeEventListener = vi.fn()
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({ matches: false, addEventListener, removeEventListener })
+  )
+  const store: Record<string, string> = {}
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value)
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        delete store[key]
+      }
+    },
+  })
+  return { addEventListener, removeEventListener }
+}
+
+const Host = defineComponent({
+  setup() {
+    useColorModes('test-color-scheme')
+    return () => null
+  },
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useColorModes', () => {
+  it('removes the matchMedia listener when the component unmounts', () => {
+    const { addEventListener, removeEventListener } = setupEnv()
+
+    const wrapper = mount(Host)
+
+    expect(addEventListener).toHaveBeenCalledTimes(1)
+    const handler = addEventListener.mock.calls[0][1]
+
+    wrapper.unmount()
+
+    expect(removeEventListener).toHaveBeenCalledWith('change', handler)
+  })
+})

--- a/packages/coreui-vue/src/composables/useColorModes.ts
+++ b/packages/coreui-vue/src/composables/useColorModes.ts
@@ -1,4 +1,4 @@
-import { onBeforeMount, ref, watch } from 'vue'
+import { onBeforeMount, onScopeDispose, ref, watch } from 'vue'
 
 const getStoredTheme = (localStorageItemName: string) =>
   typeof window !== 'undefined' && localStorage.getItem(localStorageItemName)
@@ -40,17 +40,25 @@ export const useColorModes = (localStorageItemName = 'coreui-vue-color-scheme') 
     }
   })
 
+  let mql: MediaQueryList | undefined
+  const handleColorSchemeChange = () => {
+    const storedTheme = getStoredTheme(localStorageItemName)
+    if (storedTheme !== 'light' && storedTheme !== 'dark' && colorMode.value) {
+      setTheme(colorMode.value)
+    }
+  }
+
   onBeforeMount(() => {
     if (typeof getStoredTheme(localStorageItemName) === 'string' && colorMode.value) {
       setTheme(colorMode.value)
     }
 
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-      const storedTheme = getStoredTheme(localStorageItemName)
-      if (storedTheme !== 'light' && storedTheme !== 'dark' && colorMode.value) {
-        setTheme(colorMode.value)
-      }
-    })
+    mql = window.matchMedia('(prefers-color-scheme: dark)')
+    mql.addEventListener('change', handleColorSchemeChange)
+  })
+
+  onScopeDispose(() => {
+    mql?.removeEventListener('change', handleColorSchemeChange)
   })
 
   return {


### PR DESCRIPTION
Fixes a listener leak from the July 2026 security/quality audit (P2).

The `prefers-color-scheme` `matchMedia` change listener added in `onBeforeMount` was **never removed**, so it leaked when the consuming component unmounted. Add an `onScopeDispose` cleanup that removes it. Regression test: the listener is removed on unmount.

Local validation (GitHub CI unavailable — billing): lint 0 errors, lib:build clean, lib:test green (ran via the pre-push gate).