### PR TITLE
fix(useUniqueId): stop mutating the prefix so ids don't snowball

### DIFF
--- a/packages/coreui-vue/src/composables/__tests__/useUniqueId.spec.ts
+++ b/packages/coreui-vue/src/composables/__tests__/useUniqueId.spec.ts
@@ -1,0 +1,21 @@
+import { useUniqueId } from '../useUniqueId'
+
+describe('useUniqueId', () => {
+  it('does not snowball the prefix across calls', () => {
+    const { getUID } = useUniqueId('prefix-')
+
+    const first = getUID()
+    const second = getUID()
+    const third = getUID()
+
+    for (const id of [first, second, third]) {
+      expect(id).toMatch(/^prefix-\d+$/)
+    }
+
+    // Each id is independent — later ids must not embed the earlier ones
+    // (the old implementation mutated the shared prefix, so ids grew).
+    expect(second).not.toBe(first)
+    expect(second).not.toContain(first)
+    expect(third).not.toContain(second)
+  })
+})

--- a/packages/coreui-vue/src/composables/useUniqueId.ts
+++ b/packages/coreui-vue/src/composables/useUniqueId.ts
@@ -4,12 +4,13 @@ export const useUniqueId = (prefix: string = '') => {
   const ids = ref<string[]>([])
 
   const getUID = () => {
+    let uid: string
     do {
-      prefix += Math.floor(Math.random() * 1_000_000)
-    } while (ids.value.includes(prefix))
+      uid = `${prefix}${Math.floor(Math.random() * 1_000_000)}`
+    } while (ids.value.includes(uid))
 
-    ids.value.push(prefix)
-    return prefix
+    ids.value.push(uid)
+    return uid
   }
 
   return {


### PR DESCRIPTION
Fixes a P2 correctness bug from the July 2026 security/quality audit.

`getUID()` did `prefix += …`, mutating the shared `prefix` parameter, so each successive call embedded the previous id: `prefix123`, `prefix123456`, `prefix123456789`… Build each id in a local variable so calls are independent.

Regression test asserts later ids don't contain earlier ones.

Local validation (GitHub CI unavailable — billing): lint 0 errors, lib:build clean, lib:test 690 passed (via the pre-push gate).