### PR TITLE
fix(CAlert): expose role="alert" for assistive technology

### DIFF
--- a/packages/coreui-vue/src/components/alert/CAlert.ts
+++ b/packages/coreui-vue/src/components/alert/CAlert.ts
@@ -116,6 +116,7 @@ export const CAlert = defineComponent({
             h(
               'div',
               {
+                role: 'alert',
                 ...attrs,
                 class: [
                   'alert',

--- a/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
+++ b/packages/coreui-vue/src/components/alert/__tests__/CAlert.spec.ts
@@ -8,6 +8,11 @@ describe('CAlert', () => {
       expect(wrapper.find('.alert').classes()).toContain('alert-primary')
     })
 
+    it('should expose role="alert" for assistive technology', () => {
+      const wrapper = mount(CAlert, { props: { color: 'primary' } })
+      expect(wrapper.find('.alert').attributes('role')).toBe('alert')
+    })
+
     it('should render its content', () => {
       const wrapper = mount(CAlert, {
         props: { color: 'primary' },


### PR DESCRIPTION
Fixes a11y audit #7 (Vue free regression). `CAlert` rendered a plain `div` with no role, so screen readers didn't announce it as an alert — React and Angular already set `role="alert"`. Add `role="alert"` (before the attrs spread, so consumers can still override it). Regression test added.

Ports to both Vue editions (coreui-vue + coreui-vue-pro).

> While here, verified the other #7 items are **already done** (audit was stale): CTabs has `role="tablist"/"tab"/"tabpanel"` + arrow-key nav; CStepper has the tab roles; the Vue tooltip directive already applies `aria-describedby`. Tooltip **Escape-dismiss** is genuinely missing — but in React too, so it's a separate cross-framework item, not a Vue regression.

Local validation: lint 0 errors, lib:build clean, lib:test 691 passed (via pre-push gate).