### PR TITLE
fix(Tooltip): dismiss tooltip and popover on Escape key (WCAG 1.4.13)

### DIFF
--- a/packages/coreui-vue/src/components/popover/CPopover.ts
+++ b/packages/coreui-vue/src/components/popover/CPopover.ts
@@ -1,4 +1,14 @@
-import { defineComponent, h, PropType, ref, RendererElement, Transition, useId } from 'vue'
+import {
+  defineComponent,
+  h,
+  onScopeDispose,
+  PropType,
+  ref,
+  RendererElement,
+  Transition,
+  useId,
+  watch,
+} from 'vue'
 import type { Options, Placement } from '@popperjs/core'
 
 import { CConditionalTeleport } from '../conditional-teleport'
@@ -169,6 +179,18 @@ const CPopover = defineComponent({
         : props.popperConfig),
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      setTimeout(() => {
+        visible.value = false
+      }, delay.hide)
+    }
+
     const handleEnter = (el: RendererElement, done: () => void) => {
       emit('show')
       initPopper(togglerRef.value, popoverRef.value, popperConfig)
@@ -184,6 +206,18 @@ const CPopover = defineComponent({
         destroyPopper()
       }, el as HTMLElement)
     }
+
+    watch(visible, (value) => {
+      if (value) {
+        document.addEventListener('keydown', handleKeyDown, true)
+      } else {
+        document.removeEventListener('keydown', handleKeyDown, true)
+      }
+    })
+
+    onScopeDispose(() => {
+      document.removeEventListener('keydown', handleKeyDown, true)
+    })
 
     const toggleVisible = (event: Event, _visible: boolean) => {
       togglerRef.value = event.target

--- a/packages/coreui-vue/src/components/popover/__tests__/CPopover.spec.ts
+++ b/packages/coreui-vue/src/components/popover/__tests__/CPopover.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { h } from 'vue'
 import { CPopover as Component } from '../../../index'
 
@@ -37,6 +37,74 @@ describe(`Loads and display ${ComponentName} component`, () => {
     expect(popover).not.toBeNull()
     expect(popover?.querySelector('.popover-header')?.textContent).toBe('Title')
     expect(popover?.querySelector('.popover-body')?.textContent).toBe('Body')
+
+    wrapper.unmount()
+  })
+
+  it('is dismissed when the Escape key is pressed', async () => {
+    const wrapper = mount(Component, {
+      props: { content: 'Body', title: 'Title', trigger: 'hover' },
+      slots: {
+        toggler: (props: { id: string | null; on: Record<string, (event: Event) => void> }) =>
+          h(
+            'button',
+            {
+              'aria-describedby': props.id,
+              onMouseenter: props.on.mouseenter,
+              onMouseleave: props.on.mouseleave,
+            },
+            'Toggle'
+          ),
+      },
+      attachTo: document.body,
+    })
+
+    const button = wrapper.find('button')
+    await button.trigger('mouseenter')
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('is not dismissed when a non-Escape key is pressed', async () => {
+    const wrapper = mount(Component, {
+      props: { content: 'Body', title: 'Title', trigger: 'hover' },
+      slots: {
+        toggler: (props: { id: string | null; on: Record<string, (event: Event) => void> }) =>
+          h(
+            'button',
+            {
+              'aria-describedby': props.id,
+              onMouseenter: props.on.mouseenter,
+              onMouseleave: props.on.mouseleave,
+            },
+            'Toggle'
+          ),
+      },
+      attachTo: document.body,
+    })
+
+    const button = wrapper.find('button')
+    await button.trigger('mouseenter')
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
 
     wrapper.unmount()
   })

--- a/packages/coreui-vue/src/components/tooltip/CTooltip.ts
+++ b/packages/coreui-vue/src/components/tooltip/CTooltip.ts
@@ -1,4 +1,14 @@
-import { defineComponent, h, PropType, ref, RendererElement, Transition, useId } from 'vue'
+import {
+  defineComponent,
+  h,
+  onScopeDispose,
+  PropType,
+  ref,
+  RendererElement,
+  Transition,
+  useId,
+  watch,
+} from 'vue'
 import type { Options, Placement } from '@popperjs/core'
 
 import { CConditionalTeleport } from '../conditional-teleport'
@@ -165,6 +175,18 @@ const CTooltip = defineComponent({
         : props.popperConfig),
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      setTimeout(() => {
+        visible.value = false
+      }, delay.hide)
+    }
+
     const handleEnter = (el: RendererElement, done: () => void) => {
       emit('show')
       initPopper(togglerRef.value, tooltipRef.value, popperConfig)
@@ -180,6 +202,18 @@ const CTooltip = defineComponent({
         destroyPopper()
       }, el as HTMLElement)
     }
+
+    watch(visible, (value) => {
+      if (value) {
+        document.addEventListener('keydown', handleKeyDown, true)
+      } else {
+        document.removeEventListener('keydown', handleKeyDown, true)
+      }
+    })
+
+    onScopeDispose(() => {
+      document.removeEventListener('keydown', handleKeyDown, true)
+    })
 
     const toggleVisible = (event: Event, _visible: boolean) => {
       togglerRef.value = event.target

--- a/packages/coreui-vue/src/components/tooltip/__tests__/CTooltip.spec.ts
+++ b/packages/coreui-vue/src/components/tooltip/__tests__/CTooltip.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { h } from 'vue'
 import { CTooltip as Component } from '../../../index'
 
@@ -37,6 +37,74 @@ describe(`Loads and display ${ComponentName} component`, () => {
     expect(tooltip).not.toBeNull()
     expect(tooltip?.querySelector('.tooltip-inner')?.textContent).toBe('Hello')
     expect(tooltip?.getAttribute('role')).toBe('tooltip')
+
+    wrapper.unmount()
+  })
+
+  it('is dismissed when the Escape key is pressed', async () => {
+    const wrapper = mount(Component, {
+      props: { content: 'Hello', trigger: 'hover' },
+      slots: {
+        toggler: (props: { id: string | null; on: Record<string, (event: Event) => void> }) =>
+          h(
+            'button',
+            {
+              'aria-describedby': props.id,
+              onMouseenter: props.on.mouseenter,
+              onMouseleave: props.on.mouseleave,
+            },
+            'Toggle'
+          ),
+      },
+      attachTo: document.body,
+    })
+
+    const button = wrapper.find('button')
+    await button.trigger('mouseenter')
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('is not dismissed when a non-Escape key is pressed', async () => {
+    const wrapper = mount(Component, {
+      props: { content: 'Hello', trigger: 'hover' },
+      slots: {
+        toggler: (props: { id: string | null; on: Record<string, (event: Event) => void> }) =>
+          h(
+            'button',
+            {
+              'aria-describedby': props.id,
+              onMouseenter: props.on.mouseenter,
+              onMouseleave: props.on.mouseleave,
+            },
+            'Toggle'
+          ),
+      },
+      attachTo: document.body,
+    })
+
+    const button = wrapper.find('button')
+    await button.trigger('mouseenter')
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    await new Promise((resolve) => setTimeout(resolve))
+    await flushPromises()
+
+    expect(button.attributes('aria-describedby')).toBeTruthy()
 
     wrapper.unmount()
   })

--- a/packages/docs/src/content/docs/components/popover/index.mdx
+++ b/packages/docs/src/content/docs/components/popover/index.mdx
@@ -59,6 +59,8 @@ You can customize the appearance of popovers using [CSS variables](#css-variable
 
 ## Usage
 
+A shown popover can also be dismissed by pressing the <kbd>Escape</kbd> key. As with dropdown menus, a popover shown inside a dialog is dismissed on its own: the first <kbd>Escape</kbd> closes the popover and a subsequent one closes the dialog.
+
 ### Disabled elements
 
 Elements with the disabled attribute aren't interactive, meaning users cannot hover or click them to trigger a popover (or tooltip). As a workaround, you'll want to trigger the popover from a wrapper `<div>` or `<span>`, ideally made keyboard-focusable using `tabindex="0"`.

--- a/packages/docs/src/content/docs/components/tooltip/index.mdx
+++ b/packages/docs/src/content/docs/components/tooltip/index.mdx
@@ -51,6 +51,8 @@ You can customize the appearance of tooltips using [CSS variables](#css-variable
 
 ## Usage
 
+A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping satisfy the [WCAG 1.4.13 "Content on Hover or Focus"](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion.
+
 ### Disabled elements
 
 Elements with the disabled attribute aren’t interactive, meaning users cannot focus, hover, or click them to trigger a tooltip (or popover). As a workaround, you’ll want to trigger the tooltip from a wrapper `<div>` or `<span>`, ideally made keyboard-focusable using `tabindex="0"`.


### PR DESCRIPTION
Ports the vanilla tooltip Escape-key dismissal (coreui/coreui#1126, coreui-pro#609) to the Vue `CTooltip` and `CPopover` (a11y — WCAG 1.4.13 "Content on Hover or Focus"): a hover/focus tooltip or popover could not be dismissed from the keyboard.

- A `watch(visible)` attaches a `keydown` listener on `document` in the **capture phase** while shown and removes it when hidden (plus `onScopeDispose` for unmount); on `Escape` it `preventDefault()` + `stopPropagation()` and schedules hide.
- Capture phase = the tooltip/popover dismisses **before** an ancestor dialog's own Escape handler (nested dismissal).
- Applied to both `CTooltip` and `CPopover` (separate components in Vue).
- Tests: dismiss-on-Escape + non-Escape-ignored for each component. Docs updated (tooltip/popover Usage).