### PR TITLE
ci: pin GitHub Actions to full commit SHAs, bump to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -33,8 +33,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions'


### PR DESCRIPTION
SHA-pin all GitHub Actions to immutable full commit SHAs (with `# vX.Y.Z` comments), matching upstream Bootstrap and the sweep already done in coreui/coreui-pro. A mutable tag (`@v4`) lets a compromised action repoint to malicious code that runs in CI (cf. tj-actions/changed-files). Also bumps the stale versions to current: `actions/checkout` → v7.0.0, `actions/setup-node` → v6.5.0, `actions/stale` → v10.4.0 (config inputs verified compatible). Dependabot's github-actions ecosystem maintains the SHAs going forward. Workflow YAML validated; no behaviour change beyond the version bumps.