### PR TITLE
ci: add CodeQL code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+paths-ignore:
+  - "**/dist"
+  - "**/node_modules"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+      - "!dependabot/**"
+  pull_request:
+    branches:
+      - main
+      - "!dependabot/**"
+  schedule:
+    - cron: "0 2 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
+          languages: "javascript"
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+        with:
+          category: "/language:javascript"


### PR DESCRIPTION
Adds CodeQL code scanning (JavaScript/TypeScript) to this public repo, matching the setup already running on coreui/coreui-pro. Runs on push/PR to main, weekly, and on demand; least-privilege token (`security-events: write` for the analysis job, `contents: read` otherwise); actions SHA-pinned; `dist`/`node_modules` excluded via the config. Free for public repos (no GHAS license needed). Closes the supply-chain audit gap 'add CodeQL to the public repos'.