### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5724,8 +5724,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
@@ -5738,8 +5737,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
@@ -5752,8 +5750,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
@@ -5766,8 +5763,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
@@ -5780,8 +5776,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
@@ -5794,8 +5789,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
@@ -5808,8 +5802,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
@@ -5822,8 +5815,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
@@ -5836,8 +5828,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
@@ -5850,8 +5841,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
@@ -5864,8 +5854,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
@@ -5878,8 +5867,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
@@ -5892,8 +5880,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
@@ -5906,8 +5893,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
@@ -5920,8 +5906,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
@@ -5934,8 +5919,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
@@ -5948,8 +5932,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
@@ -5962,8 +5945,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
@@ -5976,8 +5958,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
@@ -5990,8 +5971,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
@@ -6004,8 +5984,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
@@ -6018,8 +5997,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
@@ -6032,8 +6010,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
@@ -6046,8 +6023,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
@@ -6060,8 +6036,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@shikijs/core": {
       "version": "4.3.1",
@@ -27258,7 +27233,7 @@
       "dependencies": {
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/vue": "^7.0.1",
-        "@coreui/astro-docs": "0.1.0",
+        "@coreui/astro-docs": "0.1.1",
         "@coreui/chartjs": "^4.2.0",
         "@coreui/coreui": "^5.8.0",
         "@coreui/icons": "^3.1.0",
@@ -27469,12 +27444,11 @@
       ]
     },
     "packages/docs/node_modules/@coreui/astro-docs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0.tgz",
-      "integrity": "sha512-pmi5f4qz90TqWUXwffjdDWEY3FCP1DIDXyw7bHhIHTy1AVWXM7aUU482UxnKH5zWDstKNx7b0dgZgS8aXMxl6g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.1.tgz",
+      "integrity": "sha512-ucFQ2TzMi9iR35eZ3FRvyanIi+9P+TBTffnHrtuwQ2GKcCxKb38zeLs68iWo2sPDWPf7K28IZq2xNnpXzLA07Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.1",
         "@coreui/icons": "^3.1.0",
         "@coreui/internal-links": "^5.2.0",
         "@docsearch/css": "^4.6.3",
@@ -27489,6 +27463,7 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/mdx": "^7.0.0",
         "astro": "^7.0.0"
       }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/vue": "^7.0.1",
-    "@coreui/astro-docs": "0.1.0",
+    "@coreui/astro-docs": "0.1.1",
     "@coreui/chartjs": "^4.2.0",
     "@coreui/coreui": "^5.8.0",
     "@coreui/icons": "^3.1.0",


### PR DESCRIPTION
0.1.1 moves @astrojs/markdown-remark to a peer dependency, keeping docs builds working on Astro 7.1.2. Docs build verified: no broken links.