### PR TITLE
docs: fix framework name leftovers and align sidebar with PRO

### DIFF
--- a/packages/docs/src/content/docs/components/focus-trap/api.mdx
+++ b/packages/docs/src/content/docs/components/focus-trap/api.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Vue Vue Focus Trap Component API"
+title: "Vue Focus Trap Component API"
 name: "Vue Focus Trap API"
-description: "Explore the API reference for the Vue Vue Focus Trap component and discover how to effectively utilize its props for customization."
+description: "Explore the API reference for the Vue Focus Trap component and discover how to effectively utilize its props for customization."
 ---
 
 import CFocusTrapData from '@api/CFocusTrap.api.json'

--- a/packages/docs/src/content/docs/components/icon/index.mdx
+++ b/packages/docs/src/content/docs/components/icon/index.mdx
@@ -129,7 +129,7 @@ CoreUI Vue Icons leverage local CSS variables, such as `--ci-primary-color` and 
 
 ### Sizing
 
-Set heights of vue icons using size property like `size="lg"` and `size="sm"`.
+Set heights of Vue icons using size property like `size="lg"` and `size="sm"`.
 
 <Example code={IconSizingExampleRaw} name="IconSizingExample">
   <IconSizingExample client:only="vue" />

--- a/packages/docs/src/content/docs/components/modal/bootstrap.mdx
+++ b/packages/docs/src/content/docs/components/modal/bootstrap.mdx
@@ -98,7 +98,7 @@ Toggle between multiple modals with some clever placement of the `visible` props
 
 ### Change animation
 
-The variable `$modal-fade-transform` determines the transform state of React Modal component before the modal fade-in animation, whereas the variable `$modal-show-transform` determines the transform state of Modal component after the modal fade-in animation.
+The variable `$modal-fade-transform` determines the transform state of Vue Modal component before the modal fade-in animation, whereas the variable `$modal-show-transform` determines the transform state of Modal component after the modal fade-in animation.
 If you want a zoom-in animation, for example, set `$modal-fade-transform: scale(.8)`.
 
 ### Remove animation

--- a/packages/docs/src/content/docs/components/modal/index.mdx
+++ b/packages/docs/src/content/docs/components/modal/index.mdx
@@ -99,7 +99,7 @@ Toggle between multiple modals with some clever placement of the `visible` props
 
 ### Change animation
 
-The variable `$modal-fade-transform` determines the transform state of React Modal component before the modal fade-in animation, whereas the variable `$modal-show-transform` determines the transform state of Modal component after the modal fade-in animation.
+The variable `$modal-fade-transform` determines the transform state of Vue Modal component before the modal fade-in animation, whereas the variable `$modal-show-transform` determines the transform state of Modal component after the modal fade-in animation.
 If you want a zoom-in animation, for example, set `$modal-fade-transform: scale(.8)`.
 
 ### Remove animation

--- a/packages/docs/src/content/docs/components/placeholder/index.mdx
+++ b/packages/docs/src/content/docs/components/placeholder/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vue Placeholder Component"
 name: "Placeholder"
-description: "Use loading vue placeholders for your components or pages to indicate something may still be loading."
+description: "Use loading Vue placeholders for your components or pages to indicate something may still be loading."
 otherFrameworks:
   - placeholder
 ---

--- a/packages/docs/src/content/docs/forms/chip-input/styling.mdx
+++ b/packages/docs/src/content/docs/forms/chip-input/styling.mdx
@@ -14,7 +14,7 @@ Vue Chips inputs use local CSS variables on `.chip-input` for enhanced real-time
 
 ```vue
 <template>
-  <CChip :style="vars">...</CChip>
+  <CChipInput :style="vars">...</CChipInput>
 </template>
 
 <script setup>

--- a/packages/docs/src/content/docs/forms/switch/bootstrap.mdx
+++ b/packages/docs/src/content/docs/forms/switch/bootstrap.mdx
@@ -26,7 +26,7 @@ When a user interacts with the component by clicking or tapping on it, the switc
 
 ## Sizing
 
-Larger or smaller react switches? Add `size="lg"` or `size="xl"` for additional sizes.
+Larger or smaller Vue switches? Add `size="lg"` or `size="xl"` for additional sizes.
 
 <Example class="theme-bootstrap" code={FormSwitchSizingExampleRaw} name="FormSwitchSizingExample">
   <FormSwitchSizingExample client:only="vue" />

--- a/packages/docs/src/content/docs/forms/switch/index.mdx
+++ b/packages/docs/src/content/docs/forms/switch/index.mdx
@@ -27,7 +27,7 @@ When a user interacts with the component by clicking or tapping on it, the switc
 
 ## Sizing
 
-Larger or smaller react switches? Add `size="lg"` or `size="xl"` for additional sizes.
+Larger or smaller Vue switches? Add `size="lg"` or `size="xl"` for additional sizes.
 
 <Example code={FormSwitchSizingExampleRaw} name="FormSwitchSizingExample">
   <FormSwitchSizingExample client:only="vue" />

--- a/packages/docs/src/content/docs/templates/admin-dashboard/index.mdx
+++ b/packages/docs/src/content/docs/templates/admin-dashboard/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vue Templates"
 name: "Vue Templates"
-description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize vue admin panels to cover any requirement."
+description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize Vue admin panels to cover any requirement."
 ---
 
 import AdminDashboardExample from './examples/AdminDashboardExample.vue'

--- a/packages/docs/src/content/docs/templates/customize/index.mdx
+++ b/packages/docs/src/content/docs/templates/customize/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Customize vue templates"
-name: "Customize vue templates"
+title: "Customize Vue templates"
+name: "Customize Vue templates"
 description: "Learn how to theme, customize, and extend CoreUI Vue Templates with Sass, a boatload of global options."
 ---
 

--- a/packages/docs/src/content/docs/templates/download/index.mdx
+++ b/packages/docs/src/content/docs/templates/download/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Download vue templates"
-name: "Download vue templates"
-description: "Download CoreUI Vue Admin Templates to get the source code that lets you customize and create your vue-based application."
+title: "Download Vue templates"
+name: "Download Vue templates"
+description: "Download CoreUI Vue Admin Templates to get the source code that lets you customize and create your Vue-based application."
 ---
 
 ## Source files

--- a/packages/docs/src/data/sidebar.yml
+++ b/packages/docs/src/data/sidebar.yml
@@ -44,6 +44,8 @@
       badge:
         color: success
         text: New
+    - title: Floating labels
+      to: /forms/floating-labels/
     - title: Input
       to: /forms/input/
     - title: Input group
@@ -58,8 +60,6 @@
       to: /forms/switch/
     - title: Textarea
       to: /forms/textarea/
-    - title: Floating labels
-      to: /forms/floating-labels/
     - title: Layout
       to: /forms/layout/
     - title: Validation
@@ -143,6 +143,9 @@
       to: /components/table/
     - title: Tabs
       to: /components/tabs/
+      badge:
+        color: success
+        text: New
     - title: Toast
       to: /components/toast/
     - title: Tooltip


### PR DESCRIPTION
Docs-only cleanup. The free Vue docs had drifted from `coreui-vue-pro`, which received these fixes during the astro-docs migration but never got them backported.

### Content
- **Focus Trap API** — title and description read "Vue Vue Focus Trap Component API".
- **Modal** (`index.mdx` + `bootstrap.mdx`) — Sass section referred to the "React Modal component".
- **Switch** (`index.mdx` + `bootstrap.mdx`) — sizing section referred to "react switches".
- **Chip Input styling** — the CSS variables example used `<CChip>` instead of `<CChipInput>`.

### Sidebar
- Added the `New` badge to **Tabs** (present in `coreui-react`, `coreui-react-pro` and `coreui-vue-pro`).
- Moved **Floating labels** back into alphabetical order, between Chip Input and Input.

After this PR every shared free-component docs page is byte-identical to its `coreui-vue-pro` counterpart (aside from the `@coreui/vue` → `@coreui/vue-pro` import in examples), and the sidebar entries match one-to-one.

`npm run docs:build` passes (215 pages, no broken links).