### PR TITLE
docs: carry two fixes over from the pro docs

### DIFF
--- a/packages/docs/src/content/docs/ai-tools/mcp.mdx
+++ b/packages/docs/src/content/docs/ai-tools/mcp.mdx
@@ -13,7 +13,7 @@ It provides:
 - **Component documentation** — pages, props, events, and slots.
 - **Live content** — read on demand from `coreui.io`, always matching the latest release.
 - **Cross-framework links** — where each component is documented for Angular, Bootstrap, React, and Vue.
-- **Coverage of Bootstrap, React, and Vue** from a single server.
+- **Coverage of Angular, Bootstrap, React, and Vue** from a single server.
 
 The server runs locally over stdio via `npx` — no global install required.
 
@@ -118,7 +118,7 @@ Once connected, your assistant can call the following tools:
 
 | Flag | Environment variable | Default | Description |
 | --- | --- | --- | --- |
-| `--framework <list>` | `COREUI_DOCS_FRAMEWORKS` | `bootstrap,react,vue` | Enabled editions (comma-separated). The first is the default for tools. |
+| `--framework <list>` | `COREUI_DOCS_FRAMEWORKS` | `angular,bootstrap,react,vue` | Enabled editions (comma-separated). The first is the default for tools. |
 | `--base-url <url>` | `COREUI_DOCS_BASE_URL` | `https://coreui.io` | Origin of the CoreUI site. The `/<framework>/docs` path is appended automatically — override only for a staging or self-hosted mirror. |
 | `--ttl <minutes>` | `COREUI_DOCS_TTL_MINUTES` | `360` | Cache freshness window. |
 | — | `COREUI_DOCS_CACHE_DIR` | OS cache directory | On-disk cache location. |

--- a/packages/docs/src/content/docs/components/chart/index.mdx
+++ b/packages/docs/src/content/docs/components/chart/index.mdx
@@ -2,6 +2,8 @@
 title: "Vue Chart.js Component"
 name: "Chart.js"
 description: "Vue wrapper for Chart.js 3.0, the most popular charting library."
+css:
+  - "https://cdn.jsdelivr.net/npm/@coreui/chartjs@4.2.0/dist/css/coreui-chartjs.min.css"
 ---
 
 import ChartLineExample from './examples/ChartLineExample.vue'


### PR DESCRIPTION
Two fixes that landed in the pro docs and apply here verbatim.

**Chart tooltips are unstyled.** The chart components render custom HTML tooltips by default (`customTooltips`), and `.chartjs-tooltip*` ships in `@coreui/chartjs` — which no docs edition loads. Added to the page's `css:` frontmatter, pinned to the version the docs depend on (`^4.2.0`), the same way the Bootstrap docs pull in the icons stylesheet.

**The MCP page lists three editions.** `@coreui/docs-mcp` now serves Angular as well (coreui/coreui-docs-mcp#14), so the coverage line and the documented default both name all four.

Pro counterparts: coreui/coreui-vue-pro#66 and #64.