### PR TITLE
docs(chart): drop the page-level chart stylesheet, the engine bundles it

### DIFF
--- a/packages/docs/src/content/docs/components/chart/index.mdx
+++ b/packages/docs/src/content/docs/components/chart/index.mdx
@@ -2,8 +2,6 @@
 title: "Vue Chart.js Component"
 name: "Chart.js"
 description: "Vue wrapper for Chart.js 3.0, the most popular charting library."
-css:
-  - "https://cdn.jsdelivr.net/npm/@coreui/chartjs@4.2.0/dist/css/coreui-chartjs.min.css"
 ---
 
 import ChartLineExample from './examples/ChartLineExample.vue'


### PR DESCRIPTION
coreui/astro-docs#53 loads `@coreui/chartjs` in every docs build, so the CDN link on this page is a second copy of the same stylesheet.

Takes effect with the next `@coreui/astro-docs` release and pin bump — until then a clean-install build of these docs has no chart tooltip styles.